### PR TITLE
fix: dedupe vendors by name and enforce UNIQUE constraint (#75)

### DIFF
--- a/scripts/audit-duplicate-vendors.ts
+++ b/scripts/audit-duplicate-vendors.ts
@@ -1,0 +1,175 @@
+/**
+ * Audit duplicate vendor rows.
+ *
+ * Read-only. Lists every group of vendors that share a name, the rows in each
+ * group, and the number of references to each row across every dependent table.
+ *
+ * Usage: bun run scripts/audit-duplicate-vendors.ts
+ */
+import { createConnection, type Connection, type RowDataPacket } from 'mysql2/promise'
+
+interface VendorRow {
+  id: number
+  name: string
+  is_active: number
+  created_at: Date | null
+  updated_at: Date | null
+}
+
+interface RefCheck {
+  table: string
+  column: string
+  optional?: boolean
+  cast?: 'string'
+}
+
+const REF_CHECKS: RefCheck[] = [
+  { table: 'invoices', column: 'vendor', cast: 'string' },
+  { table: 'overrides', column: 'vendor_id' },
+  { table: 'expenses', column: 'vendor_id' },
+  { table: 'paystubs', column: 'vendor_id' },
+  { table: 'payroll', column: 'vendor_id' },
+  { table: 'payroll_audit', column: 'vendor_id' },
+  { table: 'vendor_field_definitions', column: 'vendor_id' },
+  { table: 'daily_pay_enrollments', column: 'vendor_id', optional: true },
+  { table: 'daily_punch_records', column: 'vendor_id', optional: true },
+  { table: 'daily_pay_records', column: 'vendor_id', optional: true },
+]
+
+function getDatabaseConfig() {
+  const databaseUrl = process.env.DATABASE_URL
+  if (databaseUrl) {
+    const url = new URL(databaseUrl)
+    const sslParam = url.searchParams.get('ssl')
+    const base = {
+      host: url.hostname,
+      port: parseInt(url.port) || 3306,
+      user: url.username,
+      password: url.password,
+      database: url.pathname.slice(1),
+    }
+    if (!sslParam) return base
+    try {
+      return { ...base, ssl: JSON.parse(sslParam) as { rejectUnauthorized: boolean } }
+    } catch {
+      return sslParam === 'true' ? { ...base, ssl: { rejectUnauthorized: false } } : base
+    }
+  }
+  return {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '3306'),
+    user: process.env.DB_USER || 'choice_user',
+    password: process.env.DB_PASSWORD || 'choice_password',
+    database: process.env.DB_NAME || 'choice_marketing',
+  }
+}
+
+async function tableExists(conn: Connection, table: string, database: string): Promise<boolean> {
+  const [rows] = await conn.query<RowDataPacket[]>(
+    'SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ? LIMIT 1',
+    [database, table],
+  )
+  return rows.length > 0
+}
+
+async function countRefs(
+  conn: Connection,
+  check: RefCheck,
+  vendorId: number,
+): Promise<number> {
+  const where = check.cast === 'string'
+    ? `${check.column} = CAST(? AS CHAR)`
+    : `${check.column} = ?`
+  const [rows] = await conn.query<RowDataPacket[]>(
+    `SELECT COUNT(*) AS cnt FROM ${check.table} WHERE ${where}`,
+    [vendorId],
+  )
+  return Number(rows[0].cnt)
+}
+
+async function audit() {
+  const config = getDatabaseConfig()
+  console.log(`Connecting to ${config.host}:${config.port}/${config.database}...`)
+
+  const conn = await createConnection(config)
+  try {
+    const activeChecks: RefCheck[] = []
+    const skipped: string[] = []
+    for (const check of REF_CHECKS) {
+      if (check.optional && !(await tableExists(conn, check.table, config.database))) {
+        skipped.push(check.table)
+        continue
+      }
+      activeChecks.push(check)
+    }
+
+    if (skipped.length > 0) {
+      console.log(`Skipping missing optional tables: ${skipped.join(', ')}\n`)
+    }
+
+    const [groupRows] = await conn.query<RowDataPacket[]>(
+      `SELECT name, COUNT(*) AS cnt
+       FROM vendors
+       GROUP BY name
+       HAVING COUNT(*) > 1
+       ORDER BY name`,
+    )
+
+    if (groupRows.length === 0) {
+      console.log('No duplicate vendor names found.')
+      return
+    }
+
+    console.log(`Found ${groupRows.length} duplicate name group(s).\n`)
+
+    for (const g of groupRows) {
+      const name = g.name as string
+      const [vendorRows] = await conn.query<RowDataPacket[]>(
+        `SELECT id, name, is_active, created_at, updated_at
+         FROM vendors
+         WHERE name = ?
+         ORDER BY is_active DESC, id ASC`,
+        [name],
+      )
+
+      console.log('='.repeat(80))
+      console.log(`Vendor name: ${JSON.stringify(name)} (${vendorRows.length} rows)`)
+      console.log('='.repeat(80))
+
+      const header = ['id', 'is_active', 'created_at', ...activeChecks.map(c => c.table)]
+      const widths = header.map(h => h.length)
+      const lines: string[][] = []
+
+      for (const v of vendorRows as VendorRow[]) {
+        const counts: number[] = []
+        for (const check of activeChecks) {
+          counts.push(await countRefs(conn, check, v.id))
+        }
+        const row = [
+          String(v.id),
+          v.is_active === 1 ? 'yes' : 'no',
+          v.created_at ? new Date(v.created_at).toISOString() : 'null',
+          ...counts.map(String),
+        ]
+        row.forEach((cell, i) => {
+          if (cell.length > widths[i]) widths[i] = cell.length
+        })
+        lines.push(row)
+      }
+
+      const fmt = (cells: string[]) =>
+        cells.map((c, i) => c.padEnd(widths[i])).join('  ')
+      console.log(fmt(header))
+      console.log(widths.map(w => '-'.repeat(w)).join('  '))
+      for (const line of lines) console.log(fmt(line))
+      console.log('')
+    }
+  } finally {
+    await conn.end()
+  }
+}
+
+audit().catch(err => {
+  console.error('Audit failed:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/scripts/merge-duplicate-vendors.ts
+++ b/scripts/merge-duplicate-vendors.ts
@@ -1,0 +1,271 @@
+/**
+ * Merge duplicate vendor rows into a single canonical row per name.
+ *
+ * Dry run by default. Pass --apply to commit changes.
+ *
+ * Canonical pick: is_active DESC, id ASC (active beats inactive; tie-breaker
+ * is the oldest id).
+ *
+ * Loser handling: rows are NOT deleted. They are marked is_active = 0 and
+ * renamed to "[archived #<id>] <original name>" so the canonical name becomes
+ * unique while preserving every loser id for historical reference (e.g.,
+ * payroll_audit.vendor_id stays resolvable).
+ *
+ * Each duplicate group is wrapped in its own transaction; a failure in one
+ * group rolls that group back and continues to the next.
+ *
+ * Reference rewrites cover the same tables the audit script reports against,
+ * minus payroll_audit (audit-only — historical record, do not rewrite).
+ *
+ * Special cases:
+ *   - invoices.vendor is a stringified id; both sides cast as CHAR.
+ *   - paystubs.vendor_name is denormalized; rewrite alongside vendor_id.
+ *   - vendor_field_definitions has UNIQUE(vendor_id, field_key); overlapping
+ *     loser rows are deleted before the re-point.
+ *
+ * Usage:
+ *   bun run scripts/merge-duplicate-vendors.ts            # dry run
+ *   bun run scripts/merge-duplicate-vendors.ts --apply    # commit
+ */
+import { createConnection, type Connection, type RowDataPacket, type ResultSetHeader } from 'mysql2/promise'
+
+const APPLY = process.argv.includes('--apply')
+
+interface VendorRow {
+  id: number
+  name: string
+  is_active: number
+}
+
+interface MergeStep {
+  table: string
+  optional?: boolean
+}
+
+const MERGE_STEPS: MergeStep[] = [
+  { table: 'invoices' },
+  { table: 'overrides' },
+  { table: 'expenses' },
+  { table: 'paystubs' },
+  { table: 'payroll' },
+  { table: 'vendor_field_definitions' },
+  { table: 'daily_pay_enrollments', optional: true },
+  { table: 'daily_punch_records', optional: true },
+  { table: 'daily_pay_records', optional: true },
+]
+
+function getDatabaseConfig() {
+  const databaseUrl = process.env.DATABASE_URL
+  if (databaseUrl) {
+    const url = new URL(databaseUrl)
+    const sslParam = url.searchParams.get('ssl')
+    const base = {
+      host: url.hostname,
+      port: parseInt(url.port) || 3306,
+      user: url.username,
+      password: url.password,
+      database: url.pathname.slice(1),
+    }
+    if (!sslParam) return base
+    try {
+      return { ...base, ssl: JSON.parse(sslParam) as { rejectUnauthorized: boolean } }
+    } catch {
+      return sslParam === 'true' ? { ...base, ssl: { rejectUnauthorized: false } } : base
+    }
+  }
+  return {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '3306'),
+    user: process.env.DB_USER || 'choice_user',
+    password: process.env.DB_PASSWORD || 'choice_password',
+    database: process.env.DB_NAME || 'choice_marketing',
+  }
+}
+
+async function tableExists(conn: Connection, table: string, database: string): Promise<boolean> {
+  const [rows] = await conn.query<RowDataPacket[]>(
+    'SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ? LIMIT 1',
+    [database, table],
+  )
+  return rows.length > 0
+}
+
+async function countLoser(conn: Connection, table: string, loserId: number): Promise<number> {
+  const where = table === 'invoices' ? 'vendor = CAST(? AS CHAR)' : 'vendor_id = ?'
+  const [rows] = await conn.query<RowDataPacket[]>(
+    `SELECT COUNT(*) AS cnt FROM ${table} WHERE ${where}`,
+    [loserId],
+  )
+  return Number(rows[0].cnt)
+}
+
+/**
+ * Re-point one table's references from loser → canonical. Returns a
+ * description of what was (or would be) done for logging.
+ */
+async function repointTable(
+  conn: Connection,
+  table: string,
+  canonical: VendorRow,
+  loserId: number,
+): Promise<string> {
+  if (table === 'invoices') {
+    const [r] = await conn.query<ResultSetHeader>(
+      'UPDATE invoices SET vendor = CAST(? AS CHAR) WHERE vendor = CAST(? AS CHAR)',
+      [canonical.id, loserId],
+    )
+    return `invoices: ${r.affectedRows} row(s) re-pointed (vendor string)`
+  }
+
+  if (table === 'paystubs') {
+    const [r] = await conn.query<ResultSetHeader>(
+      'UPDATE paystubs SET vendor_id = ?, vendor_name = ? WHERE vendor_id = ?',
+      [canonical.id, canonical.name, loserId],
+    )
+    return `paystubs: ${r.affectedRows} row(s) re-pointed (vendor_id + vendor_name)`
+  }
+
+  if (table === 'vendor_field_definitions') {
+    // Delete loser rows whose field_key already exists on the canonical row,
+    // since UNIQUE(vendor_id, field_key) would block the UPDATE.
+    const [del] = await conn.query<ResultSetHeader>(
+      `DELETE l FROM vendor_field_definitions l
+         INNER JOIN vendor_field_definitions c
+           ON c.vendor_id = ? AND c.field_key = l.field_key
+         WHERE l.vendor_id = ?`,
+      [canonical.id, loserId],
+    )
+    const [upd] = await conn.query<ResultSetHeader>(
+      'UPDATE vendor_field_definitions SET vendor_id = ? WHERE vendor_id = ?',
+      [canonical.id, loserId],
+    )
+    return `vendor_field_definitions: ${del.affectedRows} overlap(s) dropped, ${upd.affectedRows} row(s) re-pointed`
+  }
+
+  const [r] = await conn.query<ResultSetHeader>(
+    `UPDATE ${table} SET vendor_id = ? WHERE vendor_id = ?`,
+    [canonical.id, loserId],
+  )
+  return `${table}: ${r.affectedRows} row(s) re-pointed`
+}
+
+async function mergeGroup(
+  conn: Connection,
+  name: string,
+  vendors: VendorRow[],
+  activeSteps: MergeStep[],
+): Promise<{ ok: boolean; error?: string }> {
+  const [canonical, ...losers] = vendors
+  console.log('-'.repeat(80))
+  console.log(`Group: ${JSON.stringify(name)}`)
+  console.log(`  Canonical: id=${canonical.id} (is_active=${canonical.is_active})`)
+  console.log(`  Losers:    ${losers.map(l => `${l.id}(active=${l.is_active})`).join(', ')}`)
+
+  // Pre-mutation reference counts for visibility.
+  for (const loser of losers) {
+    const counts: string[] = []
+    for (const step of activeSteps) {
+      const n = await countLoser(conn, step.table, loser.id)
+      if (n > 0) counts.push(`${step.table}=${n}`)
+    }
+    console.log(`  loser ${loser.id} refs: ${counts.length ? counts.join(', ') : '(none)'}`)
+  }
+
+  await conn.query('START TRANSACTION')
+  try {
+    for (const loser of losers) {
+      console.log(`  Re-pointing loser ${loser.id} → canonical ${canonical.id}:`)
+      for (const step of activeSteps) {
+        const msg = await repointTable(conn, step.table, canonical, loser.id)
+        console.log(`    ${msg}`)
+      }
+    }
+
+    for (const loser of losers) {
+      const archivedName = `[archived #${loser.id}] ${loser.name}`
+      const [arch] = await conn.query<ResultSetHeader>(
+        `UPDATE vendors
+            SET is_active = 0,
+                name = ?,
+                updated_at = NOW()
+          WHERE id = ?`,
+        [archivedName, loser.id],
+      )
+      console.log(`  Archived loser ${loser.id}: name → ${JSON.stringify(archivedName)} (${arch.affectedRows} row)`)
+    }
+
+    if (APPLY) {
+      await conn.query('COMMIT')
+      console.log(`  COMMIT.`)
+    } else {
+      await conn.query('ROLLBACK')
+      console.log(`  ROLLBACK (dry run).`)
+    }
+    return { ok: true }
+  } catch (err) {
+    await conn.query('ROLLBACK')
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(`  ERROR — rolled back: ${msg}`)
+    return { ok: false, error: msg }
+  }
+}
+
+async function run() {
+  const config = getDatabaseConfig()
+  console.log(`Connecting to ${config.host}:${config.port}/${config.database}...`)
+  console.log(APPLY ? 'Mode: APPLY (changes will be committed)' : 'Mode: DRY RUN (no changes will be committed)')
+  console.log('')
+
+  const conn = await createConnection(config)
+  try {
+    const activeSteps: MergeStep[] = []
+    const skipped: string[] = []
+    for (const step of MERGE_STEPS) {
+      if (step.optional && !(await tableExists(conn, step.table, config.database))) {
+        skipped.push(step.table)
+        continue
+      }
+      activeSteps.push(step)
+    }
+    if (skipped.length > 0) {
+      console.log(`Skipping missing optional tables: ${skipped.join(', ')}\n`)
+    }
+
+    const [groups] = await conn.query<RowDataPacket[]>(
+      `SELECT name FROM vendors GROUP BY name HAVING COUNT(*) > 1 ORDER BY name`,
+    )
+
+    if (groups.length === 0) {
+      console.log('No duplicate vendor names found.')
+      return
+    }
+
+    let okCount = 0
+    let failCount = 0
+    for (const g of groups) {
+      const name = g.name as string
+      const [vendors] = await conn.query<RowDataPacket[]>(
+        `SELECT id, name, is_active
+         FROM vendors
+         WHERE name = ?
+         ORDER BY is_active DESC, id ASC`,
+        [name],
+      )
+      const result = await mergeGroup(conn, name, vendors as VendorRow[], activeSteps)
+      if (result.ok) okCount++
+      else failCount++
+    }
+
+    console.log('')
+    console.log('='.repeat(80))
+    console.log(`Summary: ${okCount} group(s) ${APPLY ? 'merged' : 'simulated'}, ${failCount} failed.`)
+    if (!APPLY) console.log('Re-run with --apply to commit changes.')
+  } finally {
+    await conn.end()
+  }
+}
+
+run().catch(err => {
+  console.error('Merge failed:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/src/app/api/vendors/__tests__/route.test.ts
+++ b/src/app/api/vendors/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}))
+
+jest.mock('@/lib/auth/config', () => ({
+  authOptions: {},
+}))
+
+jest.mock('@/lib/auth/payroll-access', () => ({
+  getEmployeeContext: jest.fn(),
+}))
+
+jest.mock('@/lib/repositories/VendorRepository', () => ({
+  VendorRepository: jest.fn().mockImplementation(() => ({
+    isNameAvailable: jest.fn(),
+    createVendor: jest.fn(),
+    getVendors: jest.fn(),
+  })),
+}))
+
+import { getServerSession } from 'next-auth'
+import { getEmployeeContext } from '@/lib/auth/payroll-access'
+import { VendorRepository } from '@/lib/repositories/VendorRepository'
+import { POST } from '../route'
+
+const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>
+const mockGetEmployeeContext = getEmployeeContext as jest.MockedFunction<typeof getEmployeeContext>
+const MockedVendorRepository = VendorRepository as jest.MockedClass<typeof VendorRepository>
+
+const adminSession = {
+  user: {
+    id: 'test-user-id',
+    email: 'admin@test.com',
+    isAdmin: true,
+    isManager: false,
+    isActive: true,
+    employeeId: 1,
+    salesIds: [],
+  },
+}
+
+function postRequest(body: unknown) {
+  return new Request('http://localhost:3000/api/vendors', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }) as unknown as Parameters<typeof POST>[0]
+}
+
+let isNameAvailable: jest.Mock
+let createVendor: jest.Mock
+
+describe('POST /api/vendors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    isNameAvailable = jest.fn()
+    createVendor = jest.fn()
+    MockedVendorRepository.mockImplementation(() => ({
+      isNameAvailable,
+      createVendor,
+      getVendors: jest.fn(),
+    }) as unknown as VendorRepository)
+
+    mockGetServerSession.mockResolvedValue(adminSession as never)
+    mockGetEmployeeContext.mockResolvedValue({
+      employeeId: 1,
+      isAdmin: true,
+      isManager: false,
+    } as never)
+  })
+
+  it('returns 409 when isNameAvailable rejects the name', async () => {
+    isNameAvailable.mockResolvedValue(false)
+
+    const response = await POST(postRequest({ name: 'Solar Company' }))
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toMatch(/already exists/i)
+    expect(createVendor).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when the DB UNIQUE constraint fires (race window)', async () => {
+    isNameAvailable.mockResolvedValue(true)
+    const dupErr = Object.assign(new Error('Duplicate entry'), { code: 'ER_DUP_ENTRY' })
+    createVendor.mockRejectedValue(dupErr)
+
+    const response = await POST(postRequest({ name: 'Solar Company' }))
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toMatch(/already exists/i)
+  })
+
+  it('creates the vendor when the name is available', async () => {
+    isNameAvailable.mockResolvedValue(true)
+    createVendor.mockResolvedValue({
+      id: 99,
+      name: 'New Vendor',
+      is_active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    })
+
+    const response = await POST(postRequest({ name: 'New Vendor' }))
+    const data = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(data.vendor.id).toBe(99)
+  })
+
+  it('returns 403 for non-admin users', async () => {
+    mockGetServerSession.mockResolvedValue({
+      ...adminSession,
+      user: { ...adminSession.user, isAdmin: false },
+    } as never)
+
+    const response = await POST(postRequest({ name: 'Anything' }))
+    expect(response.status).toBe(403)
+  })
+})

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -6,8 +6,6 @@ import { z } from 'zod'
 import { logger } from '@/lib/utils/logger'
 import { getEmployeeContext } from '@/lib/auth/payroll-access'
 
-const vendorRepository = new VendorRepository()
-
 const createVendorSchema = z.object({
   name: z.string().min(1, 'Vendor name is required').max(300, 'Name is too long'),
   is_active: z.boolean().optional()
@@ -41,7 +39,7 @@ export async function GET(request: NextRequest) {
       session.user.isManager
     )
 
-    const vendors = await vendorRepository.getVendors(filters, userContext)
+    const vendors = await new VendorRepository().getVendors(filters, userContext)
 
     return NextResponse.json({ vendors })
   } catch (error) {
@@ -81,6 +79,8 @@ export async function POST(request: NextRequest) {
       session.user.isManager
     )
 
+    const vendorRepository = new VendorRepository()
+
     // Check if name is available
     const isAvailable = await vendorRepository.isNameAvailable(data.name, undefined, userContext)
     if (!isAvailable) {
@@ -94,8 +94,17 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ vendor }, { status: 201 })
   } catch (error) {
+    // Race-window backstop: the DB UNIQUE constraint can fire if another
+    // request creates the same name between isNameAvailable and createVendor.
+    if (isDuplicateEntryError(error)) {
+      return NextResponse.json(
+        { error: 'A vendor with this name already exists' },
+        { status: 409 }
+      )
+    }
+
     logger.error('Error creating vendor:', error)
-    
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Validation failed', details: error.issues },
@@ -108,4 +117,13 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     )
   }
+}
+
+function isDuplicateEntryError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'ER_DUP_ENTRY'
+  )
 }

--- a/src/lib/database/migrations/008_unique_vendor_name.sql
+++ b/src/lib/database/migrations/008_unique_vendor_name.sql
@@ -1,0 +1,7 @@
+-- Enforce uniqueness on vendor names.
+--
+-- Prerequisite: scripts/merge-duplicate-vendors.ts --apply must have been
+-- run first. This migration will fail loudly if duplicate names remain.
+
+ALTER TABLE vendors
+  ADD CONSTRAINT uk_vendors_name UNIQUE (name);


### PR DESCRIPTION
Closes #75.

## Summary

- **Audit script** (`scripts/audit-duplicate-vendors.ts`, read-only): lists every duplicate vendor-name group and per-row reference counts across `invoices`, `overrides`, `expenses`, `paystubs`, `payroll`, `payroll_audit`, `vendor_field_definitions`, and (when present) `daily_pay_enrollments`/`daily_punch_records`/`daily_pay_records`.
- **Merge script** (`scripts/merge-duplicate-vendors.ts`, dry-run by default; `--apply` to commit): per duplicate group, picks the canonical row by `is_active DESC, id ASC`, re-points all FK references to the canonical id, then **soft-archives** each loser (`is_active = 0`, name → `[archived #<id>] <original>`). Each group is wrapped in its own transaction; a failure rolls that group back and the script continues to the next.
- **Migration** (`008_unique_vendor_name.sql`): adds `uk_vendors_name UNIQUE (name)` — a safety net that fails loudly if duplicates remain.
- **API hardening** (`src/app/api/vendors/route.ts`): `ER_DUP_ENTRY` backstop returns a friendly 409 if the DB UNIQUE fires in the race window between `isNameAvailable` and `createVendor`. Repository instantiation moved into the handlers (matches `marketing/products/route.ts`, makes the route mockable).
- **Tests** (`src/app/api/vendors/__tests__/route.test.ts`): four jest tests — pre-check 409, race-window 409, happy-path 201, non-admin 403.

### Why soft-archive instead of DELETE

`payroll_audit.vendor_id` (and other historical-record references we deliberately do not rewrite) need to keep resolving to a real row. Hard-deleting losers would leave dangling references. Soft-archive preserves the history while the rename keeps the canonical name unique.

### What's not rewritten

`payroll_audit` is a record of paystub deletions; rewriting `vendor_id` there would fabricate lineage. The audit script reports it for visibility, but the merge script does not touch it.

## Test plan

- [x] Jest unit tests for `POST /api/vendors` pass (4/4) locally
- [x] Typecheck and lint clean for all touched files (pre-existing failures elsewhere are unrelated)
- [x] Dry-run audit + dry-run merge + `--apply` merge ran cleanly on dev DB
- [ ] After merging: run `bun run scripts/audit-duplicate-vendors.ts` against prod DB → review
- [ ] `bun run scripts/merge-duplicate-vendors.ts` (dry) → review
- [ ] `bun run scripts/merge-duplicate-vendors.ts --apply` → confirm `SELECT name, COUNT(*) FROM vendors GROUP BY name HAVING COUNT(*) > 1` returns zero rows
- [ ] `bun run scripts/run-migrations.ts` to apply `008_unique_vendor_name.sql`
- [ ] Spot-check a few previously-deduped vendors in the UI: invoices/paystubs roll up under the canonical id

🤖 Generated with [Claude Code](https://claude.com/claude-code)