### PR TITLE
feat: email deliverability safeguards — bounce tracking, confirm-email, verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ NEXT_PUBLIC_ENV=development
 # Resend Email (required for password reset emails)
 RESEND_API_KEY="your-resend-api-key"
 
+# Resend webhook signing secret (Svix `whsec_...`). Required to verify
+# delivery/bounce webhooks at /api/webhooks/resend. Create the webhook
+# endpoint in the Resend dashboard and copy its signing secret here.
+RESEND_WEBHOOK_SECRET="whsec_..."
+
 # Careers HR notification recipient (falls back to RESEND_FROM_EMAIL, then a hardcoded default)
 CAREERS_NOTIFY_EMAIL="careers@choicemarketingpartners.com"
 

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "resend": "^6.1.3",
         "sonner": "^2.0.7",
         "stripe": "^20.3.1",
+        "svix": "^1.94.0",
         "tailwind-merge": "^3.3.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "zod": "^4.1.13",
@@ -580,6 +581,8 @@
 
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@13.0.5", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
@@ -1069,6 +1072,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -1844,6 +1849,8 @@
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
     "stream-combiner2": ["stream-combiner2@1.1.1", "", { "dependencies": { "duplexer2": "~0.1.0", "readable-stream": "^2.0.2" } }, "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw=="],
@@ -1891,6 +1898,8 @@
     "supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "svix": ["svix@1.94.0", "", { "dependencies": { "standardwebhooks": "1.0.0" } }, "sha512-FuP5nJez1P/SeK+4zOBI8RrNhtrzMTBSvwuD4yGGsn+Af2yQazid6OwPu3fpZpMifOJxrJua0su/dYB5fe4v9Q=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "resend": "^6.1.3",
     "sonner": "^2.0.7",
     "stripe": "^20.3.1",
+    "svix": "^1.94.0",
     "tailwind-merge": "^3.3.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.1.13"

--- a/src/app/(portal)/admin/employees/[id]/page.tsx
+++ b/src/app/(portal)/admin/employees/[id]/page.tsx
@@ -11,6 +11,8 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { ArrowLeft, Edit, Mail, Phone, MapPin, User, Shield, Users, UserCheck } from 'lucide-react'
 import Link from 'next/link'
 import { UserAccountActions } from '@/components/employees/UserAccountActions'
+import { EmailDeliveryRepository } from '@/lib/repositories/EmailDeliveryRepository'
+import { EmailDeliveryBadge } from '@/components/employees/EmailDeliveryBadge'
 
 interface EmployeeDetailPageProps {
   params: Promise<{
@@ -43,6 +45,10 @@ export default async function EmployeeDetailPage({ params }: EmployeeDetailPageP
   if (!employee) {
     notFound()
   }
+
+  const deliveryStatus = await new EmailDeliveryRepository().getLatestStatusForEmail(
+    employee.email
+  )
 
   const getEmployeeInitials = (name: string) => {
     return name
@@ -147,6 +153,7 @@ export default async function EmployeeDetailPage({ params }: EmployeeDetailPageP
                       Hidden from Payroll
                     </Badge>
                   )}
+                  <EmailDeliveryBadge status={deliveryStatus} />
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -185,6 +192,7 @@ export default async function EmployeeDetailPage({ params }: EmployeeDetailPageP
             email: employee.email,
             hasUser: !!employee.user,
           }}
+          emailUnverified={!!employee.user && employee.user.emailVerifiedAt === null}
         />
 
         {/* Contact Information */}

--- a/src/app/(portal)/admin/employees/email-alerts/page.tsx
+++ b/src/app/(portal)/admin/employees/email-alerts/page.tsx
@@ -1,0 +1,128 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/config'
+import { EmailDeliveryRepository } from '@/lib/repositories/EmailDeliveryRepository'
+import { EmployeeRepository } from '@/lib/repositories/EmployeeRepository'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ArrowLeft, MailX, MailCheck, ShieldCheck } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Email Alerts | Choice Marketing Partners',
+  description: 'Employees with undeliverable email addresses',
+}
+
+export default async function EmailAlertsPage() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.isAdmin) {
+    redirect('/')
+  }
+
+  const [undeliverable, verificationStats] = await Promise.all([
+    new EmailDeliveryRepository().listUndeliverable(),
+    new EmployeeRepository().getEmailVerificationStats(),
+  ])
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex items-center gap-4">
+          <Link href="/admin/employees">
+            <Button variant="outline" size="sm">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Employees
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold">Email Alerts</h1>
+            <p className="text-muted-foreground">
+              Employees whose most recent email bounced or was marked as spam
+            </p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5" />
+              Email Verification Adoption
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="rounded-lg border p-4">
+                <div className="text-2xl font-bold">{verificationStats.verified}</div>
+                <div className="text-sm text-muted-foreground">Verified accounts</div>
+              </div>
+              <div className="rounded-lg border p-4">
+                <div className="text-2xl font-bold">{verificationStats.pending}</div>
+                <div className="text-sm text-muted-foreground">
+                  Awaiting email verification
+                </div>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground mt-3">
+              Accounts created while the <code>require-email-verification</code> flag
+              is enabled stay pending until the employee verifies their email.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <MailX className="h-5 w-5" />
+              Undeliverable Addresses
+              <Badge variant={undeliverable.length > 0 ? 'destructive' : 'secondary'}>
+                {undeliverable.length}
+              </Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {undeliverable.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
+                <MailCheck className="h-4 w-4" />
+                No delivery problems detected. All recorded employee emails are
+                reaching their inboxes.
+              </div>
+            ) : (
+              <div className="divide-y">
+                {undeliverable.map((row) => (
+                  <Link
+                    key={`${row.employeeId}-${row.email}`}
+                    href={`/admin/employees/${row.employeeId}`}
+                    className="flex items-center justify-between py-3 hover:bg-muted/50 -mx-2 px-2 rounded"
+                  >
+                    <div>
+                      <div className="font-medium">{row.employeeName}</div>
+                      <div className="text-sm text-muted-foreground">{row.email}</div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      {row.occurredAt && (
+                        <span className="text-xs text-muted-foreground">
+                          {new Date(row.occurredAt).toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric',
+                          })}
+                        </span>
+                      )}
+                      <Badge variant="destructive" className="text-xs">
+                        {row.eventType === 'email.complained'
+                          ? 'Marked as spam'
+                          : `Bounced${row.bounceType ? ` (${row.bounceType})` : ''}`}
+                      </Badge>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(portal)/admin/employees/page.tsx
+++ b/src/app/(portal)/admin/employees/page.tsx
@@ -7,7 +7,7 @@ import { getEmployeeContext } from '@/lib/auth/payroll-access'
 import { EmployeeList } from '@/components/employees/EmployeeList'
 import { EmployeeFilters } from '@/components/employees/EmployeeFilters'
 import { Button } from '@/components/ui/button'
-import { Plus } from 'lucide-react'
+import { Plus, MailX } from 'lucide-react'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
@@ -66,12 +66,20 @@ export default async function EmployeesPage({ searchParams: paramsPromise }: Emp
             Manage employees and their user accounts
           </p>
         </div>
-        <Link href="/admin/employees/create">
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            Add Employee
-          </Button>
-        </Link>
+        <div className="flex gap-2">
+          <Link href="/admin/employees/email-alerts">
+            <Button variant="outline">
+              <MailX className="mr-2 h-4 w-4" />
+              Email Alerts
+            </Button>
+          </Link>
+          <Link href="/admin/employees/create">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Employee
+            </Button>
+          </Link>
+        </div>
       </div>
 
       {/* Statistics */}

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/config'
+import { db } from '@/lib/database/client'
+import { generateEmailVerificationToken } from '@/lib/auth/email-verification'
+import { sendVerificationEmail } from '@/lib/services/email'
+import { logger } from '@/lib/utils/logger'
+
+/**
+ * POST /api/auth/resend-verification
+ * Admin-triggered re-send of the email-verification message for an employee
+ * whose linked user account has not yet verified its email.
+ */
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.isAdmin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    const { employeeId } = await request.json()
+    const id = Number(employeeId)
+    if (!id || Number.isNaN(id)) {
+      return NextResponse.json({ error: 'Valid employeeId is required' }, { status: 400 })
+    }
+
+    const row = await db
+      .selectFrom('employees')
+      .innerJoin('employee_user', 'employees.id', 'employee_user.employee_id')
+      .innerJoin('users', 'employee_user.user_id', 'users.uid')
+      .select(['users.uid as uid', 'users.email as email', 'users.email_verified_at as emailVerifiedAt'])
+      .where('employees.id', '=', id)
+      .executeTakeFirst()
+
+    if (!row) {
+      return NextResponse.json(
+        { error: 'This employee does not have a user account' },
+        { status: 404 }
+      )
+    }
+
+    if (row.emailVerifiedAt) {
+      return NextResponse.json(
+        { error: 'This account has already verified its email' },
+        { status: 400 }
+      )
+    }
+
+    const token = generateEmailVerificationToken(row.email, String(row.uid))
+    const baseUrl =
+      process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+    const verifyUrl = `${baseUrl}/auth/verify-email?token=${token}`
+
+    const result = await sendVerificationEmail(row.email, verifyUrl)
+    if (!result.success) {
+      logger.error('Failed to resend verification email:', result.error)
+      return NextResponse.json(
+        { error: 'Failed to send verification email' },
+        { status: 502 }
+      )
+    }
+
+    return NextResponse.json({ message: `Verification email re-sent to ${row.email}` })
+  } catch (error) {
+    logger.error('Resend verification error:', error)
+    return NextResponse.json(
+      { error: 'An error occurred processing your request' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/lib/database/client'
+import { validateEmailVerificationToken } from '@/lib/auth/email-verification'
+import bcrypt from 'bcryptjs'
+import { logger } from '@/lib/utils/logger'
+
+/**
+ * POST /api/auth/verify-email
+ * Validates an email-verification token, sets the account password, and
+ * marks the email as verified so the user can sign in.
+ */
+export async function POST(request: Request) {
+  try {
+    const { token, password } = await request.json()
+
+    if (!token || typeof token !== 'string') {
+      return NextResponse.json({ error: 'Token is required' }, { status: 400 })
+    }
+
+    if (!password || typeof password !== 'string' || password.length < 8) {
+      return NextResponse.json(
+        { error: 'Password must be at least 8 characters' },
+        { status: 400 }
+      )
+    }
+
+    const payload = validateEmailVerificationToken(token)
+    if (!payload) {
+      return NextResponse.json(
+        { error: 'Invalid or expired verification link' },
+        { status: 400 }
+      )
+    }
+
+    // The verification token carries the user's uid (auto-increment PK)
+    const user = await db
+      .selectFrom('users')
+      .select(['uid', 'email', 'email_verified_at'])
+      .where('uid', '=', parseInt(payload.userId))
+      .where('email', '=', payload.email)
+      .executeTakeFirst()
+
+    if (!user) {
+      return NextResponse.json({ error: 'Account not found' }, { status: 404 })
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 12)
+
+    await db
+      .updateTable('users')
+      .set({
+        password: hashedPassword,
+        email_verified_at: new Date(),
+        updated_at: new Date(),
+      })
+      .where('uid', '=', user.uid)
+      .execute()
+
+    return NextResponse.json({
+      message: 'Email verified successfully. You can now sign in with your new password.',
+    })
+  } catch (error) {
+    logger.error('Email verification error:', error)
+    return NextResponse.json(
+      { error: 'An error occurred processing your request' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/employees/[id]/create-user/route.ts
+++ b/src/app/api/employees/[id]/create-user/route.ts
@@ -4,7 +4,9 @@ import { authOptions } from '@/lib/auth/config'
 import { db } from '@/lib/database/client'
 import bcrypt from 'bcryptjs'
 import { z } from 'zod'
-import { sendWelcomeEmail } from '@/lib/services/email'
+import { sendWelcomeEmail, sendVerificationEmail } from '@/lib/services/email'
+import { generateEmailVerificationToken } from '@/lib/auth/email-verification'
+import { isFeatureEnabled } from '@/lib/feature-flags'
 import { logger } from '@/lib/utils/logger'
 
 // Generate secure random password
@@ -118,7 +120,16 @@ export async function POST(
       })
     }
 
-    // No existing user — create a new one
+    // No existing user — create a new one.
+    // When the verification flag is on, the account starts unverified and the
+    // generated password is a throwaway (the user sets their own via email).
+    const requireVerification = await isFeatureEnabled('require-email-verification', {
+      userId: session.user.id,
+      isAdmin: session.user.isAdmin,
+      isManager: session.user.isManager ?? false,
+      isSubscriber: false,
+      subscriberId: null,
+    })
     const password = generatePassword(10)
     const hashedPassword = await bcrypt.hash(password, 12)
 
@@ -133,6 +144,7 @@ export async function POST(
           name: employee.name,
           password: hashedPassword,
           role: role,
+          email_verified_at: requireVerification ? null : new Date(),
           created_at: new Date(),
           updated_at: new Date(),
         })
@@ -158,6 +170,32 @@ export async function POST(
 
       return user
     })
+
+    // Verification flow: send a verification link, never expose a password
+    if (requireVerification) {
+      try {
+        const token = generateEmailVerificationToken(employee.email, String(result.id))
+        const baseUrl =
+          process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+        await sendVerificationEmail(
+          employee.email,
+          `${baseUrl}/auth/verify-email?token=${token}`
+        )
+      } catch (emailError) {
+        logger.error('Failed to send verification email:', emailError)
+      }
+
+      return NextResponse.json({
+        success: true,
+        message: `User account created. A verification email has been sent to ${employee.email}.`,
+        verificationSent: true,
+        user: {
+          id: result.id,
+          email: result.email,
+          role: result.role,
+        },
+      })
+    }
 
     // Send welcome email
     try {

--- a/src/app/api/employees/route.ts
+++ b/src/app/api/employees/route.ts
@@ -3,7 +3,9 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
 import { EmployeeRepository } from '@/lib/repositories/EmployeeRepository'
 import { generatePassword } from '@/lib/utils/password'
-import { sendWelcomeEmail } from '@/lib/services/email'
+import { sendWelcomeEmail, sendVerificationEmail } from '@/lib/services/email'
+import { generateEmailVerificationToken } from '@/lib/auth/email-verification'
+import { isFeatureEnabled } from '@/lib/feature-flags'
 import { z } from 'zod'
 import { logger } from '@/lib/utils/logger'
 import { getEmployeeContext } from '@/lib/auth/payroll-access'
@@ -23,6 +25,7 @@ const employeeFiltersSchema = z.object({
 const createEmployeeSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   email: z.string().email('Valid email is required'),
+  confirmEmail: z.string().min(1, 'Please confirm the email address'),
   phone_no: z.string().optional(),
   address: z.string().min(1, 'Address is required'),
   address_2: z.string().optional(),
@@ -40,7 +43,10 @@ const createEmployeeSchema = z.object({
   createUser: z.boolean().optional().default(false),
   password: z.string().optional(), // Optional - will auto-generate if not provided
   userRole: z.enum(['admin', 'author', 'subscriber']).optional().default('subscriber')
-})
+}).refine(
+  (d) => d.email.trim().toLowerCase() === d.confirmEmail.trim().toLowerCase(),
+  { message: 'Email addresses do not match', path: ['confirmEmail'] }
+)
 
 /**
  * GET /api/employees - Get paginated list of employees with filtering
@@ -105,10 +111,24 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Generate password if user creation is requested but no password provided
+    // When the verification flag is on, new accounts must verify their email
+    // and set their own password before first login.
+    const requireVerification = data.createUser
+      ? await isFeatureEnabled('require-email-verification', {
+          userId: session.user.id,
+          isAdmin: session.user.isAdmin,
+          isManager: session.user.isManager ?? false,
+          isSubscriber: false,
+          subscriberId: null,
+        })
+      : false
+
+    // Generate password if user creation is requested but no password provided.
+    // In verification mode this value is a throwaway (never shared) — the user
+    // sets their real password through the verification link.
     let generatedPassword: string | undefined
     let userPassword: string | undefined
-    
+
     if (data.createUser) {
       if (data.password) {
         // Use provided password
@@ -148,29 +168,51 @@ export async function POST(request: NextRequest) {
       },
       data.createUser && userPassword ? {
         password: userPassword,
-        role: data.userRole
+        role: data.userRole,
+        requireVerification
       } : undefined,
       userContext
     )
 
-    // Send welcome email if user account was created
-    if (data.createUser && userPassword) {
-      try {
-        await sendWelcomeEmail({
-          to: data.email,
-          name: data.name,
-          password: userPassword
-        })
-      } catch (emailError) {
-        // Log email error but don't fail the employee creation
-        logger.error('Failed to send welcome email:', emailError)
+    // Send the appropriate onboarding email if a user account was created
+    let verificationSent = false
+    if (data.createUser && userPassword && employee.user) {
+      if (requireVerification) {
+        try {
+          const token = generateEmailVerificationToken(
+            employee.user.email,
+            String(employee.user.uid)
+          )
+          const baseUrl =
+            process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+          await sendVerificationEmail(
+            employee.user.email,
+            `${baseUrl}/auth/verify-email?token=${token}`
+          )
+          verificationSent = true
+        } catch (emailError) {
+          logger.error('Failed to send verification email:', emailError)
+        }
+      } else {
+        try {
+          await sendWelcomeEmail({
+            to: data.email,
+            name: data.name,
+            password: userPassword
+          })
+        } catch (emailError) {
+          // Log email error but don't fail the employee creation
+          logger.error('Failed to send welcome email:', emailError)
+        }
       }
     }
 
-    return NextResponse.json({ 
+    return NextResponse.json({
       employee,
-      // Only return generated password to admin (not stored anywhere)
-      generatedPassword: generatedPassword
+      // Only return the generated password when verification is off; in
+      // verification mode the user sets their own password.
+      generatedPassword: requireVerification ? undefined : generatedPassword,
+      verificationSent
     }, { status: 201 })
   } catch (error) {
     logger.error('Error creating employee:', error)

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server'
+import { verifyResendWebhook } from '@/lib/services/resend-webhook'
+import { EmailDeliveryRepository } from '@/lib/repositories/EmailDeliveryRepository'
+import { logger } from '@/lib/utils/logger'
+
+/** Resend event types we persist; others are acknowledged but ignored. */
+const TRACKED_EVENTS = new Set([
+  'email.sent',
+  'email.delivered',
+  'email.delivery_delayed',
+  'email.bounced',
+  'email.complained',
+])
+
+/**
+ * POST /api/webhooks/resend — receives Resend (Svix-signed) delivery webhooks
+ * and records bounce/delivery events so undeliverable employee emails surface.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.text()
+    const svixId = request.headers.get('svix-id')
+    const svixTimestamp = request.headers.get('svix-timestamp')
+    const svixSignature = request.headers.get('svix-signature')
+
+    if (!svixId || !svixTimestamp || !svixSignature) {
+      logger.error('Resend webhook: missing Svix signature headers')
+      return NextResponse.json({ error: 'Missing signature headers' }, { status: 400 })
+    }
+
+    let event
+    try {
+      event = verifyResendWebhook(body, {
+        'svix-id': svixId,
+        'svix-timestamp': svixTimestamp,
+        'svix-signature': svixSignature,
+      })
+    } catch (err) {
+      logger.error('Resend webhook signature verification failed:', err)
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
+    }
+
+    logger.info(`Resend webhook received: ${event.type}`)
+
+    if (TRACKED_EVENTS.has(event.type)) {
+      const repo = new EmailDeliveryRepository()
+      const recipients = Array.isArray(event.data?.to)
+        ? event.data.to
+        : event.data?.to
+          ? [event.data.to]
+          : []
+      const occurredAt = event.created_at ? new Date(event.created_at) : null
+
+      for (const email of recipients) {
+        await repo.recordEvent({
+          // Svix delivers at-least-once; the unique svix_id makes inserts
+          // idempotent. Multi-recipient events get a per-recipient suffix.
+          svixId: recipients.length > 1 ? `${svixId}:${email}` : svixId,
+          email,
+          eventType: event.type,
+          resendEmailId: event.data?.email_id ?? null,
+          subject: event.data?.subject ?? null,
+          bounceType: event.data?.bounce?.type ?? null,
+          occurredAt,
+          payload: event,
+        })
+      }
+    } else {
+      logger.info(`Resend webhook: unhandled event type ${event.type}`)
+    }
+
+    return NextResponse.json({ received: true })
+  } catch (error) {
+    logger.error('Resend webhook error:', error)
+    return NextResponse.json({ error: 'Webhook handler failed' }, { status: 500 })
+  }
+}

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useState, useEffect, Suspense } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useIsClient } from '@/hooks/useIsClient'
+
+function VerifyEmailForm() {
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const isClient = useIsClient()
+  const token = searchParams.get('token')
+
+  useEffect(() => {
+    if (isClient && !token) {
+      setError('Invalid verification link. Please ask an administrator to resend it.')
+    }
+  }, [isClient, token])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters')
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      const response = await fetch('/api/auth/verify-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        setError(data.error || 'Failed to verify email')
+        setLoading(false)
+        return
+      }
+
+      setSuccess(true)
+      setTimeout(() => {
+        router.push('/auth/signin')
+      }, 3000)
+    } catch {
+      setError('An error occurred. Please try again.')
+      setLoading(false)
+    }
+  }
+
+  if (!isClient) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="animate-pulse">
+          <div className="max-w-md w-full space-y-8">
+            <div className="h-8 bg-muted rounded w-3/4 mx-auto"></div>
+            <div className="h-10 bg-muted rounded"></div>
+            <div className="h-10 bg-muted rounded"></div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-md w-full text-center">
+          <div className="rounded-md bg-primary/10 p-4">
+            <h3 className="text-lg font-medium text-primary">
+              Email Verified!
+            </h3>
+            <p className="mt-2 text-sm text-primary">
+              Your account is ready. Redirecting to sign in page...
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-foreground">
+            Verify your email
+          </h2>
+          <p className="mt-2 text-center text-sm text-muted-foreground">
+            Set a password to finish setting up your account
+          </p>
+        </div>
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <div className="rounded-md shadow-sm -space-y-px">
+            <div>
+              <label htmlFor="password" className="sr-only">
+                New Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-border placeholder-muted-foreground text-foreground rounded-t-md focus:outline-none focus:ring-primary focus:border-primary focus:z-10 sm:text-sm"
+                placeholder="New password (min 8 characters)"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                minLength={8}
+              />
+            </div>
+            <div>
+              <label htmlFor="confirm-password" className="sr-only">
+                Confirm Password
+              </label>
+              <input
+                id="confirm-password"
+                name="confirm-password"
+                type="password"
+                required
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-border placeholder-muted-foreground text-foreground rounded-b-md focus:outline-none focus:ring-primary focus:border-primary focus:z-10 sm:text-sm"
+                placeholder="Confirm new password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                minLength={8}
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-destructive/10 p-4">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+
+          <div>
+            <button
+              type="submit"
+              disabled={loading || !token}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50"
+            >
+              {loading ? 'Verifying...' : 'Verify & set password'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default function VerifyEmail() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="animate-pulse">
+          <div className="max-w-md w-full space-y-8">
+            <div className="h-8 bg-muted rounded w-3/4 mx-auto"></div>
+            <div className="h-10 bg-muted rounded"></div>
+            <div className="h-10 bg-muted rounded"></div>
+          </div>
+        </div>
+      </div>
+    }>
+      <VerifyEmailForm />
+    </Suspense>
+  )
+}

--- a/src/components/emails/VerifyEmail.tsx
+++ b/src/components/emails/VerifyEmail.tsx
@@ -1,0 +1,64 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Text,
+} from '@react-email/components'
+
+interface VerifyEmailProps {
+  verifyUrl: string
+  email: string
+}
+
+export default function VerifyEmail({ verifyUrl, email }: VerifyEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Verify your Choice Marketing Partners account</Preview>
+      <Body style={{ backgroundColor: '#f6f9fc', fontFamily: 'sans-serif' }}>
+        <Container style={{ margin: '0 auto', padding: '20px 0 48px' }}>
+          <Heading style={{ fontSize: '24px', fontWeight: 'bold', marginBottom: '20px' }}>
+            Verify your email address
+          </Heading>
+          <Text style={{ fontSize: '16px', lineHeight: '24px' }}>
+            Hello,
+          </Text>
+          <Text style={{ fontSize: '16px', lineHeight: '24px' }}>
+            An account was created for you at Choice Marketing Partners ({email}).
+          </Text>
+          <Text style={{ fontSize: '16px', lineHeight: '24px' }}>
+            Click the button below to verify this email address and set your
+            password. You&apos;ll need to do this before you can sign in.
+          </Text>
+          <Link
+            href={verifyUrl}
+            style={{
+              backgroundColor: '#5F51E8',
+              borderRadius: '3px',
+              color: '#fff',
+              fontSize: '16px',
+              textDecoration: 'none',
+              textAlign: 'center',
+              display: 'block',
+              padding: '12px',
+              marginTop: '20px',
+              marginBottom: '20px',
+            }}
+          >
+            Verify &amp; set password
+          </Link>
+          <Text style={{ fontSize: '14px', lineHeight: '24px', color: '#666' }}>
+            If you weren&apos;t expecting this, you can safely ignore this email.
+          </Text>
+          <Text style={{ fontSize: '14px', lineHeight: '24px', color: '#666' }}>
+            For security, this link will expire in 7 days.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}

--- a/src/components/employees/CreateUserDialog.tsx
+++ b/src/components/employees/CreateUserDialog.tsx
@@ -43,6 +43,7 @@ export function CreateUserDialog({
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
   const [generatedPassword, setGeneratedPassword] = useState('')
+  const [verificationSent, setVerificationSent] = useState(false)
   const [copied, setCopied] = useState(false)
 
   const handleSubmit = async () => {
@@ -63,6 +64,7 @@ export function CreateUserDialog({
 
       const data = await response.json()
       setGeneratedPassword(data.password || '')
+      setVerificationSent(!!data.verificationSent)
       setSuccess(true)
     } catch (error) {
       setError(error instanceof Error ? error.message : 'Failed to create user account')
@@ -84,6 +86,7 @@ export function CreateUserDialog({
       setError('')
       setSuccess(false)
       setGeneratedPassword('')
+      setVerificationSent(false)
       setCopied(false)
     }, 300)
   }
@@ -110,7 +113,9 @@ export function CreateUserDialog({
               <Check className="h-4 w-4" />
               <AlertTitle>Success!</AlertTitle>
               <AlertDescription>
-                {generatedPassword
+                {verificationSent
+                  ? `User account created. A verification email has been sent to ${employeeEmail}; they will set their own password before first sign-in.`
+                  : generatedPassword
                   ? `User account created successfully. A welcome email has been sent to ${employeeEmail}.`
                   : `An existing user account was found and linked to this employee. No new password was generated.`}
               </AlertDescription>
@@ -136,7 +141,7 @@ export function CreateUserDialog({
                   </Button>
                 </div>
                 <p className="text-sm text-muted-foreground">
-                  Save this password - it won't be shown again.
+                  Save this password - it won&apos;t be shown again.
                 </p>
               </div>
             )}
@@ -149,7 +154,10 @@ export function CreateUserDialog({
           <div className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="role">User Role</Label>
-              <Select value={role} onValueChange={(value: any) => setRole(value)}>
+              <Select
+                value={role}
+                onValueChange={(value) => setRole(value as 'admin' | 'author' | 'subscriber')}
+              >
                 <SelectTrigger id="role">
                   <SelectValue placeholder="Select a role" />
                 </SelectTrigger>

--- a/src/components/employees/EmailDeliveryBadge.tsx
+++ b/src/components/employees/EmailDeliveryBadge.tsx
@@ -1,0 +1,57 @@
+import { Badge } from '@/components/ui/badge'
+import { Mail, MailCheck, MailWarning, MailX } from 'lucide-react'
+import type { EmailDeliveryStatus } from '@/lib/repositories/EmailDeliveryRepository'
+
+/**
+ * Presentational badge summarizing the most recent email delivery event for an
+ * address. Renders nothing for benign "sent" state to avoid badge noise; shows
+ * a clear warning when mail bounced or was marked as spam.
+ */
+export function EmailDeliveryBadge({ status }: { status: EmailDeliveryStatus | null }) {
+  if (!status) {
+    return (
+      <Badge variant="outline" className="text-xs">
+        <Mail className="mr-1 h-3 w-3" />
+        No delivery data
+      </Badge>
+    )
+  }
+
+  switch (status.eventType) {
+    case 'email.bounced':
+      return (
+        <Badge variant="destructive" className="text-xs">
+          <MailX className="mr-1 h-3 w-3" />
+          Email bounced
+        </Badge>
+      )
+    case 'email.complained':
+      return (
+        <Badge variant="destructive" className="text-xs">
+          <MailX className="mr-1 h-3 w-3" />
+          Marked as spam
+        </Badge>
+      )
+    case 'email.delivery_delayed':
+      return (
+        <Badge variant="secondary" className="text-xs">
+          <MailWarning className="mr-1 h-3 w-3" />
+          Delivery delayed
+        </Badge>
+      )
+    case 'email.delivered':
+      return (
+        <Badge variant="default" className="text-xs">
+          <MailCheck className="mr-1 h-3 w-3" />
+          Email delivered
+        </Badge>
+      )
+    default:
+      return (
+        <Badge variant="outline" className="text-xs">
+          <Mail className="mr-1 h-3 w-3" />
+          Email sent
+        </Badge>
+      )
+  }
+}

--- a/src/components/employees/EmployeeForm.tsx
+++ b/src/components/employees/EmployeeForm.tsx
@@ -23,11 +23,13 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [generatedPassword, setGeneratedPassword] = useState<string | null>(null)
+  const [verificationSent, setVerificationSent] = useState(false)
 
   // Form state
   const [formData, setFormData] = useState({
     name: employee?.name || '',
     email: employee?.email || '',
+    confirmEmail: '',
     phone_no: employee?.phone_no || '',
     address: employee?.address || '',
     address_2: employee?.address_2 || '',
@@ -55,6 +57,16 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
     e.preventDefault()
     setIsLoading(true)
     setError('')
+
+    // Require a matching re-typed email on create to catch address typos
+    if (
+      mode === 'create' &&
+      formData.email.trim().toLowerCase() !== formData.confirmEmail.trim().toLowerCase()
+    ) {
+      setError('Email addresses do not match')
+      setIsLoading(false)
+      return
+    }
 
     try {
       const employeeData: CreateEmployeeData = {
@@ -88,6 +100,7 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
         ? employeeData
         : {
             ...employeeData,
+            confirmEmail: formData.confirmEmail,
             createUser: formData.createUser,
             userRole: formData.role
             // Password is optional - backend will auto-generate if not provided
@@ -104,9 +117,12 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
 
       if (response.ok) {
         const result = await response.json()
-        
-        // Store generated password if provided
-        if (result.generatedPassword) {
+
+        if (result.verificationSent) {
+          // Verification flow: employee sets their own password via email
+          setVerificationSent(true)
+        } else if (result.generatedPassword) {
+          // Store generated password if provided
           setGeneratedPassword(result.generatedPassword)
         } else {
           // No generated password, redirect immediately
@@ -126,6 +142,25 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
 
   return (
     <div className="space-y-6">
+      {/* Success message when an email-verification link was sent */}
+      {verificationSent && (
+        <Card className="border-primary bg-primary/10">
+          <CardHeader>
+            <CardTitle className="text-primary">Employee Created Successfully! 🎉</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-primary">
+              A verification email has been sent to <strong>{formData.email}</strong>.
+              The employee must verify their email and set a password before they
+              can sign in.
+            </p>
+            <Button onClick={() => router.push('/admin/employees')}>
+              Go to Employee List
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Success message with generated password */}
       {generatedPassword && (
         <Card className="border-primary bg-primary/10">
@@ -209,6 +244,24 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
                   required
                 />
               </div>
+
+              {mode === 'create' && (
+                <div className="space-y-2">
+                  <Label htmlFor="confirmEmail">Confirm Email Address *</Label>
+                  <Input
+                    id="confirmEmail"
+                    type="email"
+                    value={formData.confirmEmail}
+                    onChange={(e) => handleInputChange('confirmEmail', e.target.value)}
+                    onPaste={(e) => e.preventDefault()}
+                    placeholder="Re-type email address"
+                    required
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Re-type the address to avoid typos. Pasting is disabled.
+                  </p>
+                </div>
+              )}
 
               <div className="space-y-2">
                 <Label htmlFor="phone_no">Phone Number</Label>

--- a/src/components/employees/UserAccountActions.tsx
+++ b/src/components/employees/UserAccountActions.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Key, UserPlus } from 'lucide-react'
+import { Key, UserPlus, Mail } from 'lucide-react'
 import { PasswordResetDialog } from './PasswordResetDialog'
 import { CreateUserDialog } from './CreateUserDialog'
 
@@ -14,11 +15,36 @@ interface UserAccountActionsProps {
     email: string
     hasUser: boolean
   }
+  /** True when the linked user account exists but has not verified its email. */
+  emailUnverified?: boolean
 }
 
-export function UserAccountActions({ employee }: UserAccountActionsProps) {
+export function UserAccountActions({ employee, emailUnverified = false }: UserAccountActionsProps) {
   const [showPasswordReset, setShowPasswordReset] = useState(false)
   const [showCreateUser, setShowCreateUser] = useState(false)
+  const [resending, setResending] = useState(false)
+
+  const handleResendVerification = async () => {
+    setResending(true)
+    try {
+      const res = await fetch('/api/auth/resend-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ employeeId: employee.id }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to resend verification email')
+      }
+      toast.success(data.message || 'Verification email sent')
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to resend verification email'
+      )
+    } finally {
+      setResending(false)
+    }
+  }
 
   return (
     <>
@@ -26,21 +52,36 @@ export function UserAccountActions({ employee }: UserAccountActionsProps) {
         <CardHeader>
           <CardTitle>User Account Actions</CardTitle>
           <CardDescription>
-            {employee.hasUser
-              ? 'Manage user account for this employee'
-              : 'This employee does not have a user account yet'}
+            {!employee.hasUser
+              ? 'This employee does not have a user account yet'
+              : emailUnverified
+                ? 'This account has not verified its email address yet'
+                : 'Manage user account for this employee'}
           </CardDescription>
         </CardHeader>
         <CardContent>
           {employee.hasUser ? (
-            <Button
-              onClick={() => setShowPasswordReset(true)}
-              variant="default"
-              className="w-full sm:w-auto"
-            >
-              <Key className="mr-2 h-4 w-4" />
-              Reset Password
-            </Button>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Button
+                onClick={() => setShowPasswordReset(true)}
+                variant="default"
+                className="w-full sm:w-auto"
+              >
+                <Key className="mr-2 h-4 w-4" />
+                Reset Password
+              </Button>
+              {emailUnverified && (
+                <Button
+                  onClick={handleResendVerification}
+                  variant="outline"
+                  disabled={resending}
+                  className="w-full sm:w-auto"
+                >
+                  <Mail className="mr-2 h-4 w-4" />
+                  {resending ? 'Sending...' : 'Resend verification email'}
+                </Button>
+              )}
+            </div>
           ) : (
             <Button
               onClick={() => setShowCreateUser(true)}

--- a/src/lib/auth/__tests__/email-verification.test.ts
+++ b/src/lib/auth/__tests__/email-verification.test.ts
@@ -1,0 +1,61 @@
+import {
+  generateEmailVerificationToken,
+  validateEmailVerificationToken,
+} from '../email-verification'
+import { generatePasswordResetToken } from '../password-reset'
+import jwt from 'jsonwebtoken'
+
+describe('Email Verification Token', () => {
+  const email = 'newhire@example.com'
+  const userId = '456'
+
+  describe('generateEmailVerificationToken', () => {
+    it('generates a valid JWT token', () => {
+      const token = generateEmailVerificationToken(email, userId)
+      expect(token).toBeTruthy()
+      expect(typeof token).toBe('string')
+      expect(token.split('.')).toHaveLength(3) // JWT format
+    })
+  })
+
+  describe('validateEmailVerificationToken', () => {
+    it('validates a valid token and returns the payload', () => {
+      const token = generateEmailVerificationToken(email, userId)
+      const payload = validateEmailVerificationToken(token)
+
+      expect(payload).toBeTruthy()
+      expect(payload?.email).toBe(email)
+      expect(payload?.userId).toBe(userId)
+      expect(payload?.type).toBe('email-verification')
+    })
+
+    it('returns null for a malformed token', () => {
+      expect(validateEmailVerificationToken('invalid.token.here')).toBeNull()
+    })
+
+    it('returns null for an expired token', () => {
+      const secret = process.env.NEXTAUTH_SECRET || 'fallback-secret-for-dev'
+      const expired = jwt.sign(
+        { email, userId, type: 'email-verification' },
+        secret,
+        { expiresIn: -10 }
+      )
+      expect(validateEmailVerificationToken(expired)).toBeNull()
+    })
+
+    it('rejects a password-reset token (wrong type)', () => {
+      // A token minted for a different purpose must not pass verification.
+      const resetToken = generatePasswordResetToken(email, userId)
+      expect(validateEmailVerificationToken(resetToken)).toBeNull()
+    })
+
+    it('returns null for a token signed with a different secret', () => {
+      const foreign = jwt.sign(
+        { email, userId, type: 'email-verification' },
+        'a-different-secret',
+        { expiresIn: '7d' }
+      )
+      expect(validateEmailVerificationToken(foreign)).toBeNull()
+    })
+  })
+})

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -3,6 +3,7 @@ import CredentialsProvider from 'next-auth/providers/credentials'
 import bcrypt from 'bcryptjs'
 import { db } from '@/lib/database/client'
 import { logger } from '@/lib/utils/logger'
+import { isFeatureEnabled } from '@/lib/feature-flags'
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -21,7 +22,7 @@ export const authOptions: NextAuthOptions = {
           // Find user by email
           const user = await db
             .selectFrom('users')
-            .select(['id', 'email', 'password', 'name'])
+            .select(['id', 'email', 'password', 'name', 'email_verified_at'])
             .where('email', '=', credentials.email)
             .executeTakeFirst()
 
@@ -31,9 +32,27 @@ export const authOptions: NextAuthOptions = {
 
           // Verify password
           const isValidPassword = await bcrypt.compare(credentials.password, user.password)
-          
+
           if (!isValidPassword) {
             return null
+          }
+
+          // Email verification gate (feature-flagged). Accounts created before
+          // the verification flow are grandfathered with a non-null
+          // email_verified_at, so only genuinely unverified accounts are blocked.
+          if (user.email_verified_at == null) {
+            const mustVerify = await isFeatureEnabled('require-email-verification', {
+              userId: String(user.id),
+              isAdmin: false,
+              isManager: false,
+              isSubscriber: false,
+              subscriberId: null,
+            })
+            if (mustVerify) {
+              throw new Error(
+                'Please verify your email address before signing in. Check your inbox for the verification link.'
+              )
+            }
           }
 
           // Get employee data for role information - direct relationship
@@ -87,6 +106,11 @@ export const authOptions: NextAuthOptions = {
             ].filter(Boolean) as string[]
           }
         } catch (error) {
+          // Surface the email-verification gate message to the client;
+          // swallow everything else as a generic auth failure.
+          if (error instanceof Error && error.message.startsWith('Please verify your email')) {
+            throw error
+          }
           logger.error('Authentication error:', error)
           return null
         }

--- a/src/lib/auth/email-verification.ts
+++ b/src/lib/auth/email-verification.ts
@@ -1,0 +1,44 @@
+import jwt from 'jsonwebtoken'
+
+/**
+ * Signed JWT tokens for the employee email-verification flow. Mirrors
+ * password-reset.ts but with its own token `type` and a longer expiry
+ * window appropriate for onboarding.
+ */
+
+const JWT_SECRET = process.env.NEXTAUTH_SECRET || 'fallback-secret-for-dev'
+const TOKEN_EXPIRY = '7d' // onboarding window
+
+export interface EmailVerificationPayload {
+  email: string
+  userId: string
+  type: 'email-verification'
+  exp?: number
+  iat?: number
+}
+
+/** Generate a signed verification token for a newly created user account. */
+export function generateEmailVerificationToken(email: string, userId: string): string {
+  const payload: EmailVerificationPayload = {
+    email,
+    userId,
+    type: 'email-verification',
+  }
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: TOKEN_EXPIRY })
+}
+
+/**
+ * Validate and decode a verification token.
+ * Returns the payload if valid, or null if invalid, expired, or wrong type.
+ */
+export function validateEmailVerificationToken(token: string): EmailVerificationPayload | null {
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET) as EmailVerificationPayload
+    if (decoded.type !== 'email-verification') {
+      return null
+    }
+    return decoded
+  } catch {
+    return null
+  }
+}

--- a/src/lib/database/migrations/009_email_delivery_events.sql
+++ b/src/lib/database/migrations/009_email_delivery_events.sql
@@ -1,0 +1,19 @@
+-- Email delivery event log (idempotent)
+-- Append-only record of Resend webhook events, keyed by recipient email address.
+-- No changes to employees/users — delivery status is correlated by email string.
+
+CREATE TABLE IF NOT EXISTS email_delivery_events (
+  id               INT AUTO_INCREMENT PRIMARY KEY,
+  svix_id          VARCHAR(255) NOT NULL,
+  email            VARCHAR(255) NOT NULL,
+  event_type       VARCHAR(50)  NOT NULL,
+  resend_email_id  VARCHAR(255) NULL,
+  subject          VARCHAR(255) NULL,
+  bounce_type      VARCHAR(50)  NULL,
+  payload          JSON NULL,
+  occurred_at      TIMESTAMP NULL,
+  created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_svix_id (svix_id),
+  KEY idx_email (email),
+  KEY idx_event_type (event_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/lib/database/migrations/010_email_verification.sql
+++ b/src/lib/database/migrations/010_email_verification.sql
@@ -1,0 +1,32 @@
+-- Email verification before first login (idempotent)
+
+-- Add users.email_verified_at if it does not already exist.
+-- The grandfather UPDATE runs only when the column is first added, so
+-- pre-existing accounts are marked verified and never gated, while accounts
+-- created afterwards under the verification flow keep a NULL value.
+DROP PROCEDURE IF EXISTS _add_email_verified_at;
+DELIMITER $$
+CREATE PROCEDURE _add_email_verified_at()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'users'
+      AND COLUMN_NAME  = 'email_verified_at'
+  ) THEN
+    ALTER TABLE users ADD COLUMN email_verified_at TIMESTAMP NULL DEFAULT NULL;
+    UPDATE users SET email_verified_at = COALESCE(created_at, NOW());
+  END IF;
+END$$
+DELIMITER ;
+CALL _add_email_verified_at();
+DROP PROCEDURE IF EXISTS _add_email_verified_at;
+
+-- Seed the require-email-verification flag (disabled, 0% rollout, all environments).
+-- Toggle/ramp it from the admin feature-flags UI.
+INSERT IGNORE INTO feature_flags (name, description, is_enabled, rollout_percentage, environment)
+VALUES (
+  'require-email-verification',
+  'Require new employees to verify their email and set a password before first login',
+  0, 0, 'all'
+);

--- a/src/lib/database/types.ts
+++ b/src/lib/database/types.ts
@@ -446,6 +446,7 @@ export interface Users {
   created_at: Date | null;
   deleted_at: Date | null;
   email: string;
+  email_verified_at: Generated<Date | null>;
   id: number;
   name: string;
   password: string;
@@ -562,8 +563,22 @@ export interface ProductMarketing {
   updated_at: Generated<Date | null>;
 }
 
+export interface EmailDeliveryEvents {
+  bounce_type: string | null;
+  created_at: Generated<Date>;
+  email: string;
+  event_type: string;
+  id: Generated<number>;
+  occurred_at: Date | null;
+  payload: string | null;
+  resend_email_id: string | null;
+  subject: string | null;
+  svix_id: string;
+}
+
 export interface DB {
   comments: Comments;
+  email_delivery_events: EmailDeliveryEvents;
   company_options: CompanyOptions;
   document_files: DocumentFiles;
   documents: Documents;

--- a/src/lib/repositories/EmailDeliveryRepository.ts
+++ b/src/lib/repositories/EmailDeliveryRepository.ts
@@ -1,0 +1,172 @@
+import { db } from '@/lib/database/client'
+
+/**
+ * Resend webhook event types we record. `email.bounced` and `email.complained`
+ * mark an address as undeliverable; the others are informational.
+ */
+export type EmailDeliveryEventType =
+  | 'email.sent'
+  | 'email.delivered'
+  | 'email.delivery_delayed'
+  | 'email.bounced'
+  | 'email.complained'
+
+/** Event types that mean the address could not receive mail. */
+export const UNDELIVERABLE_EVENT_TYPES = ['email.bounced', 'email.complained'] as const
+
+export interface RecordDeliveryEventInput {
+  svixId: string
+  email: string
+  eventType: string
+  resendEmailId?: string | null
+  subject?: string | null
+  bounceType?: string | null
+  occurredAt?: Date | null
+  payload?: unknown
+}
+
+export interface EmailDeliveryStatus {
+  email: string
+  eventType: string
+  bounceType: string | null
+  subject: string | null
+  occurredAt: Date | null
+  createdAt: Date
+}
+
+export interface UndeliverableEmployee {
+  employeeId: number
+  employeeName: string
+  email: string
+  eventType: string
+  bounceType: string | null
+  subject: string | null
+  occurredAt: Date | null
+}
+
+/**
+ * Append-only log of Resend email delivery webhook events.
+ * Delivery status is correlated to employees/users by recipient email address.
+ */
+export class EmailDeliveryRepository {
+  /**
+   * Record a webhook event. Idempotent: a repeated `svixId` (Svix delivers
+   * at-least-once) is ignored via INSERT IGNORE on the unique key.
+   */
+  async recordEvent(input: RecordDeliveryEventInput): Promise<void> {
+    await db
+      .insertInto('email_delivery_events')
+      .ignore()
+      .values({
+        svix_id: input.svixId,
+        email: input.email.trim().toLowerCase(),
+        event_type: input.eventType,
+        resend_email_id: input.resendEmailId ?? null,
+        subject: input.subject ?? null,
+        bounce_type: input.bounceType ?? null,
+        occurred_at: input.occurredAt ?? null,
+        payload: input.payload !== undefined ? JSON.stringify(input.payload) : null,
+      })
+      .execute()
+  }
+
+  /** Most recent delivery event for a single email address, or null if none. */
+  async getLatestStatusForEmail(email: string): Promise<EmailDeliveryStatus | null> {
+    const row = await db
+      .selectFrom('email_delivery_events')
+      .select(['email', 'event_type', 'bounce_type', 'subject', 'occurred_at', 'created_at'])
+      .where('email', '=', email.trim().toLowerCase())
+      .orderBy('occurred_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(1)
+      .executeTakeFirst()
+
+    if (!row) return null
+    return {
+      email: row.email,
+      eventType: row.event_type,
+      bounceType: row.bounce_type,
+      subject: row.subject,
+      occurredAt: row.occurred_at,
+      createdAt: row.created_at,
+    }
+  }
+
+  /** Latest delivery event for many addresses at once, keyed by lowercased email. */
+  async getLatestStatusForEmails(emails: string[]): Promise<Map<string, EmailDeliveryStatus>> {
+    const result = new Map<string, EmailDeliveryStatus>()
+    const normalized = [...new Set(emails.map((e) => e.trim().toLowerCase()))].filter(Boolean)
+    if (normalized.length === 0) return result
+
+    const rows = await db
+      .selectFrom('email_delivery_events as ede')
+      .innerJoin(
+        (eb) =>
+          eb
+            .selectFrom('email_delivery_events')
+            .select('email')
+            .select((e) => e.fn.max('id').as('max_id'))
+            .where('email', 'in', normalized)
+            .groupBy('email')
+            .as('latest'),
+        (join) => join.onRef('latest.max_id', '=', 'ede.id')
+      )
+      .select(['ede.email', 'ede.event_type', 'ede.bounce_type', 'ede.subject', 'ede.occurred_at', 'ede.created_at'])
+      .execute()
+
+    for (const row of rows) {
+      result.set(row.email, {
+        email: row.email,
+        eventType: row.event_type,
+        bounceType: row.bounce_type,
+        subject: row.subject,
+        occurredAt: row.occurred_at,
+        createdAt: row.created_at,
+      })
+    }
+    return result
+  }
+
+  /**
+   * Active employees whose most recent email delivery event marks the address
+   * as undeliverable (bounced or complained).
+   */
+  async listUndeliverable(): Promise<UndeliverableEmployee[]> {
+    const rows = await db
+      .selectFrom('email_delivery_events as ede')
+      .innerJoin(
+        (eb) =>
+          eb
+            .selectFrom('email_delivery_events')
+            .select('email')
+            .select((e) => e.fn.max('id').as('max_id'))
+            .groupBy('email')
+            .as('latest'),
+        (join) => join.onRef('latest.max_id', '=', 'ede.id')
+      )
+      .innerJoin('employees', 'employees.email', 'ede.email')
+      .where('ede.event_type', 'in', [...UNDELIVERABLE_EVENT_TYPES])
+      .where('employees.deleted_at', 'is', null)
+      .select([
+        'employees.id as employee_id',
+        'employees.name as employee_name',
+        'ede.email',
+        'ede.event_type',
+        'ede.bounce_type',
+        'ede.subject',
+        'ede.occurred_at',
+      ])
+      .orderBy('ede.occurred_at', 'desc')
+      .execute()
+
+    return rows.map((r) => ({
+      employeeId: r.employee_id,
+      employeeName: r.employee_name,
+      email: r.email,
+      eventType: r.event_type,
+      bounceType: r.bounce_type,
+      subject: r.subject,
+      occurredAt: r.occurred_at,
+    }))
+  }
+}

--- a/src/lib/repositories/EmployeeRepository.ts
+++ b/src/lib/repositories/EmployeeRepository.ts
@@ -36,6 +36,7 @@ export interface EmployeeDetail extends EmployeeSummary {
     email: string
     role: string
     created_at: Date | null
+    emailVerifiedAt: Date | null
   }
 }
 
@@ -61,6 +62,12 @@ export interface CreateEmployeeData {
 export interface CreateUserData {
   password: string
   role?: 'admin' | 'author' | 'subscriber'
+  /**
+   * When true, the account is created unverified (email_verified_at = NULL).
+   * The supplied password is a throwaway; the user sets a real one through
+   * the email-verification flow.
+   */
+  requireVerification?: boolean
 }
 
 export interface EmployeeFilters {
@@ -236,7 +243,8 @@ export class EmployeeRepository {
         'users.uid as user_uid',
         'users.email as user_email',
         'users.role as user_role',
-        'users.created_at as user_created_at'
+        'users.created_at as user_created_at',
+        'users.email_verified_at as user_email_verified_at'
       ])
       .where('employees.id', '=', id)
       .executeTakeFirst()
@@ -278,7 +286,8 @@ export class EmployeeRepository {
         uid: employee.user_uid,
         email: employee.user_email!,
         role: employee.user_role!,
-        created_at: employee.user_created_at
+        created_at: employee.user_created_at,
+        emailVerifiedAt: employee.user_email_verified_at ?? null
       } : undefined
     }
   }
@@ -418,6 +427,7 @@ export class EmployeeRepository {
         email: '', // Will be populated from employee email
         password: hashedPassword,
         role: userData.role || 'subscriber',
+        email_verified_at: userData.requireVerification ? null : new Date(),
         created_at: new Date(),
         updated_at: new Date()
       })
@@ -502,6 +512,7 @@ export class EmployeeRepository {
             email: employeeData.email,
             password: hashedPassword,
             role: userData.role || 'subscriber',
+            email_verified_at: userData.requireVerification ? null : new Date(),
             created_at: new Date(),
             updated_at: new Date()
           })
@@ -547,7 +558,8 @@ export class EmployeeRepository {
           'users.uid as user_uid',
           'users.email as user_email',
           'users.role as user_role',
-          'users.created_at as user_created_at'
+          'users.created_at as user_created_at',
+          'users.email_verified_at as user_email_verified_at'
         ])
         .where('employees.id', '=', employeeId)
         .executeTakeFirstOrThrow()
@@ -577,10 +589,36 @@ export class EmployeeRepository {
           uid: createdEmployee.user_uid,
           email: createdEmployee.user_email!,
           role: createdEmployee.user_role!,
-          created_at: createdEmployee.user_created_at
+          created_at: createdEmployee.user_created_at,
+          emailVerifiedAt: createdEmployee.user_email_verified_at ?? null
         } : undefined
       }
     })
+  }
+
+  /**
+   * Counts of user accounts by email-verification state — used to measure
+   * adoption of the email-verification flow.
+   */
+  async getEmailVerificationStats(): Promise<{ pending: number; verified: number }> {
+    const pendingRow = await db
+      .selectFrom('users')
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .where('deleted_at', 'is', null)
+      .where('email_verified_at', 'is', null)
+      .executeTakeFirst()
+
+    const verifiedRow = await db
+      .selectFrom('users')
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .where('deleted_at', 'is', null)
+      .where('email_verified_at', 'is not', null)
+      .executeTakeFirst()
+
+    return {
+      pending: Number(pendingRow?.count ?? 0),
+      verified: Number(verifiedRow?.count ?? 0),
+    }
   }
 
   /**

--- a/src/lib/repositories/__tests__/EmailDeliveryRepository.test.ts
+++ b/src/lib/repositories/__tests__/EmailDeliveryRepository.test.ts
@@ -1,0 +1,86 @@
+import { EmailDeliveryRepository } from '../EmailDeliveryRepository'
+import { db } from '@/lib/database/client'
+
+jest.mock('@/lib/database/client', () => ({
+  db: {
+    insertInto: jest.fn(),
+    selectFrom: jest.fn(),
+  },
+}))
+
+describe('EmailDeliveryRepository', () => {
+  let repo: EmailDeliveryRepository
+
+  beforeEach(() => {
+    repo = new EmailDeliveryRepository()
+    jest.clearAllMocks()
+  })
+
+  describe('recordEvent', () => {
+    it('normalizes the email, serializes payload, and uses an idempotent insert', async () => {
+      const execute = jest.fn().mockResolvedValue(undefined)
+      const values = jest.fn().mockReturnValue({ execute })
+      const ignore = jest.fn().mockReturnValue({ values })
+      ;(db.insertInto as jest.Mock).mockReturnValue({ ignore })
+
+      await repo.recordEvent({
+        svixId: 'msg_123',
+        email: '  HappyVWDude@Gmail.com ',
+        eventType: 'email.bounced',
+        bounceType: 'hard',
+        payload: { type: 'email.bounced' },
+      })
+
+      expect(db.insertInto).toHaveBeenCalledWith('email_delivery_events')
+      // INSERT IGNORE makes a repeated svix_id a no-op
+      expect(ignore).toHaveBeenCalled()
+
+      const inserted = values.mock.calls[0][0]
+      expect(inserted.email).toBe('happyvwdude@gmail.com')
+      expect(inserted.svix_id).toBe('msg_123')
+      expect(inserted.event_type).toBe('email.bounced')
+      expect(inserted.bounce_type).toBe('hard')
+      expect(inserted.payload).toBe(JSON.stringify({ type: 'email.bounced' }))
+      expect(execute).toHaveBeenCalled()
+    })
+
+    it('stores a null payload when none is provided', async () => {
+      const execute = jest.fn().mockResolvedValue(undefined)
+      const values = jest.fn().mockReturnValue({ execute })
+      const ignore = jest.fn().mockReturnValue({ values })
+      ;(db.insertInto as jest.Mock).mockReturnValue({ ignore })
+
+      await repo.recordEvent({
+        svixId: 'msg_456',
+        email: 'a@b.com',
+        eventType: 'email.delivered',
+      })
+
+      expect(values.mock.calls[0][0].payload).toBeNull()
+    })
+  })
+
+  describe('getLatestStatusForEmail', () => {
+    it('returns null when no delivery events exist for the address', async () => {
+      const chain: Record<string, jest.Mock> = {}
+      for (const m of ['select', 'where', 'orderBy', 'limit']) {
+        chain[m] = jest.fn().mockReturnValue(chain)
+      }
+      chain.executeTakeFirst = jest.fn().mockResolvedValue(undefined)
+      ;(db.selectFrom as jest.Mock).mockReturnValue(chain)
+
+      const result = await repo.getLatestStatusForEmail('nobody@example.com')
+      expect(result).toBeNull()
+      // email is normalized before querying
+      expect(chain.where).toHaveBeenCalledWith('email', '=', 'nobody@example.com')
+    })
+  })
+
+  describe('getLatestStatusForEmails', () => {
+    it('returns an empty map for an empty input list', async () => {
+      const result = await repo.getLatestStatusForEmails([])
+      expect(result.size).toBe(0)
+      expect(db.selectFrom).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/services/email.ts
+++ b/src/lib/services/email.ts
@@ -1,4 +1,7 @@
 import { Resend } from 'resend'
+import { render } from '@react-email/render'
+import React from 'react'
+import VerifyEmail from '@/components/emails/VerifyEmail'
 import { logger } from '@/lib/utils/logger'
 
 /**
@@ -210,7 +213,7 @@ export async function sendPasswordResetEmail(
     }
 
     logger.log('✅ Password reset email sent successfully:', { id: data?.id, to })
-    return { 
+    return {
       success: true,
       messageId: data?.id
     }
@@ -219,6 +222,42 @@ export async function sendPasswordResetEmail(
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error'
+    }
+  }
+}
+
+/**
+ * Sends an email-verification message to a newly created employee account.
+ * The recipient clicks through to verify the address and set their password.
+ * @param to Recipient email
+ * @param verifyUrl Verification link (contains the signed token)
+ */
+export async function sendVerificationEmail(
+  to: string,
+  verifyUrl: string,
+): Promise<EmailResponse> {
+  try {
+    const html = await render(React.createElement(VerifyEmail, { verifyUrl, email: to }))
+
+    const { data, error } = await resend.emails.send({
+      from: FROM_EMAIL,
+      to,
+      subject: 'Verify your email — Choice Marketing Partners',
+      html,
+    })
+
+    if (error) {
+      logger.error('❌ Resend error (verification email):', error)
+      return { success: false, error: error.message || 'Failed to send email' }
+    }
+
+    logger.log('✅ Verification email sent successfully:', { id: data?.id, to })
+    return { success: true, messageId: data?.id }
+  } catch (error) {
+    logger.error('❌ Failed to send verification email:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
     }
   }
 }

--- a/src/lib/services/resend-webhook.ts
+++ b/src/lib/services/resend-webhook.ts
@@ -1,0 +1,36 @@
+import { Webhook } from 'svix'
+
+/**
+ * Shape of a Resend webhook event payload (subset we use).
+ * See https://resend.com/docs/dashboard/webhooks/event-types
+ */
+export interface ResendWebhookEvent {
+  type: string
+  created_at?: string
+  data: {
+    email_id?: string
+    to?: string[] | string
+    subject?: string
+    bounce?: { type?: string; subType?: string }
+  }
+}
+
+export interface SvixHeaders {
+  'svix-id': string
+  'svix-timestamp': string
+  'svix-signature': string
+}
+
+/**
+ * Verify a Resend webhook request. Resend signs webhooks with Svix; the
+ * signature is verified against RESEND_WEBHOOK_SECRET (a `whsec_...` value).
+ * Throws if the signature is invalid or the secret is not configured.
+ */
+export function verifyResendWebhook(rawBody: string, headers: SvixHeaders): ResendWebhookEvent {
+  const secret = process.env.RESEND_WEBHOOK_SECRET
+  if (!secret) {
+    throw new Error('RESEND_WEBHOOK_SECRET is not configured')
+  }
+  const wh = new Webhook(secret)
+  return wh.verify(rawBody, headers) as ResendWebhookEvent
+}


### PR DESCRIPTION
## Why

A new employee's email was stored with a typo (`happvwdude@` vs `happyvwdude@`) and went unnoticed for weeks — three people reviewed the record without catching it, and nothing in the system reacted to the welcome email silently failing to deliver. The account looked fine; the person just couldn't sign in.

This PR adds three layered safeguards so a bad employee email **surfaces automatically** instead of relying on manual review.

## What's included

### 1. Resend bounce/delivery webhook + alerts dashboard
- New `email_delivery_events` table (migration `009`) — append-only log, idempotent on Svix message id.
- `POST /api/webhooks/resend` — verifies the Svix signature (`RESEND_WEBHOOK_SECRET`) and records `email.sent/delivered/delivery_delayed/bounced/complained` events.
- `EmailDeliveryRepository` + a delivery-status badge on the employee detail view.
- New admin dashboard at `/admin/employees/email-alerts` listing employees with undeliverable addresses.

### 2. Confirm-email field on employee creation
- Re-typed email field (paste-blocked) on the create form, with server-side `.refine()` match validation.

### 3. Email verification before first login — behind the `require-email-verification` flag
- Migration `010` adds `users.email_verified_at`, **grandfathers all existing users**, and seeds the flag **disabled**.
- New accounts (when the flag is on) receive a verification link instead of a plaintext password, verify their inbox, and set their own password — removing the emailed-password anti-pattern.
- Sign-in is gated for unverified accounts; admins get a "Resend verification" action; the dashboard shows verified-vs-pending adoption counts.

## Verification

- ✅ `bun lint` — clean across all changed/new files
- ✅ `bun test` — full suite green (256 tests), incl. 10 new tests (`email-verification` token module, `EmailDeliveryRepository`). The one failing suite (`marketing/products`) is a pre-existing jest-hoisting bug on `main`.
- ⚠️ Migrations, E2E, and the live webhook test were **not run** — local MySQL was unavailable in the dev environment.

## Before merge / deploy

1. Run `bun run db:migrate` (dev + production).
2. Set `RESEND_WEBHOOK_SECRET`; create the `/api/webhooks/resend` endpoint in the Resend dashboard.
3. Enable `require-email-verification` from `/admin/feature-flags` when ready (ships disabled).

## Notes

- `types.ts` was hand-updated for the two new schema objects (`kysely-codegen` needs a live DB).
- New dependency: `svix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)