### PR TITLE
Fix: paystub detail 404 for non-admins (vendor_custom_fields)

### DIFF
--- a/src/lib/repositories/PayrollRepository.ts
+++ b/src/lib/repositories/PayrollRepository.ts
@@ -507,8 +507,11 @@ export class PayrollRepository {
       return { ...sale, custom_fields: customFields }
     })
 
-    // Fetch vendor field configuration (only if feature flag is enabled)
-    let fieldConfig: Awaited<ReturnType<VendorFieldRepository['getFieldsByVendor']>> = []
+    // Fetch vendor field configuration (only if feature flag is enabled).
+    // Use the non-privileged display read — anyone authorized to view this
+    // paystub may read the vendor's field labels. getFieldsByVendor is admin-only
+    // and would throw for the employee viewing their own paystub.
+    let fieldConfig: Awaited<ReturnType<VendorFieldRepository['getActiveFieldsForDisplay']>> = []
     const flagEnabled = await isFeatureEnabled('vendor_custom_fields', {
       userId: String(userContext.employeeId ?? ''),
       isAdmin: userContext.isAdmin,
@@ -518,7 +521,7 @@ export class PayrollRepository {
     })
     if (flagEnabled) {
       const vendorFieldRepo = new VendorFieldRepository()
-      fieldConfig = await vendorFieldRepo.getFieldsByVendor(vendorId, false, userContext)
+      fieldConfig = await vendorFieldRepo.getActiveFieldsForDisplay(vendorId)
     }
 
     return {

--- a/src/lib/repositories/VendorFieldRepository.ts
+++ b/src/lib/repositories/VendorFieldRepository.ts
@@ -105,6 +105,34 @@ export class VendorFieldRepository {
   }
 
   /**
+   * Read active field definitions for rendering a paystub. Unlike
+   * getFieldsByVendor (admin management), this is a non-privileged display read:
+   * any user already authorized to view the paystub may read the vendor's field
+   * labels/order. Returns only active fields.
+   */
+  async getActiveFieldsForDisplay(vendorId: number): Promise<VendorFieldDefinition[]> {
+    const rows = await db
+      .selectFrom('vendor_field_definitions')
+      .selectAll()
+      .where('vendor_id', '=', vendorId)
+      .where('is_active', '=', 1)
+      .orderBy('display_order', 'asc')
+      .execute()
+
+    return rows.map(row => ({
+      id: row.id,
+      vendor_id: row.vendor_id,
+      field_key: row.field_key,
+      field_label: row.field_label,
+      source: row.source,
+      display_order: row.display_order,
+      is_active: row.is_active === 1,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    }))
+  }
+
+  /**
    * Check if a vendor has been configured (has any field definitions).
    */
   async isVendorConfigured(vendorId: number, userContext: UserContext): Promise<boolean> {


### PR DESCRIPTION
## Summary

Fixes a production 404 on the employee paystub detail page (`/payroll/[employeeId]/[vendorId]/[issueDate]`) for **non-admin users** whenever the `vendor_custom_fields` flag is enabled for them.

**Root cause:** `PayrollRepository.getPaystubDetail` (employee-facing) called `VendorFieldRepository.getFieldsByVendor`, which begins with:

```ts
if (!userContext?.isAdmin) {
  throw new Error('Admin access required')
}
```

When the flag is on for a non-admin, that throw is caught by the page's try/catch and converted to `notFound()` → the user sees **404 Page Not Found** on their own paystub. It also surfaced when an admin **emulated** an employee (emulation forces `isAdmin=false`), which is how it was discovered.

**Fix:** add `getActiveFieldsForDisplay(vendorId)` — a non-privileged, read-only method returning only active field definitions — and route `getPaystubDetail` through it. Access to the paystub itself is already enforced upstream (`hasEmployeeAccess`), and field labels/order aren't sensitive. The admin-only `getFieldsByVendor` is unchanged for the management UI.

## Why this matters now

This is a pre-existing bug independent of any feature branch. Any non-admin employee for whom `vendor_custom_fields` is enabled currently gets a 404 on their paystub detail in production. Shipping separately to `main` so it can go out without waiting on other work.

## How it was found / verified

- Reproduced in dev by enabling `vendor_custom_fields` for a non-admin employee and loading their paystub → 404; disabling it → renders. Toggling only the flag flips the behavior.
- Verified the fix by calling `getPaystubDetail(..., { isAdmin: false })` with the flag on: returns the paystub object with `fieldConfig.length = 6` instead of throwing.
- `bun run test` for VendorField/PayrollRepository: passing.

## Test plan

- [x] Non-admin context + flag on → paystub detail renders (was 404)
- [x] Field labels still populate (`fieldConfig` returned)
- [ ] Reviewer: admin field-management UI (`getFieldsByVendor`) still behaves (unchanged, still admin-gated)
- [ ] Reviewer: confirm in prod for Ronald Strickland (employee 1238) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)