### PR TITLE
fix: hide unreleased future-dated paystubs from non-admins

### DIFF
--- a/src/lib/repositories/PayrollRepository.ts
+++ b/src/lib/repositories/PayrollRepository.ts
@@ -4,6 +4,11 @@ import { VendorFieldRepository } from '@/lib/repositories/VendorFieldRepository'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { logger } from '@/lib/utils/logger'
 import type { UserContext } from '@/lib/auth/types'
+import {
+  getEmployeeVisibilityCutoff,
+  DEFAULT_RELEASE_HOUR,
+  DEFAULT_RELEASE_MINUTE,
+} from '@/lib/utils/payroll-visibility'
 
 
 export interface PayrollFilters {
@@ -161,6 +166,10 @@ export class PayrollRepository {
     const limit = filters.limit || 20
     const offset = (page - 1) * limit
 
+    // Non-admins may only see paystubs whose issue_date has been released.
+    // Future-dated paystubs stay hidden until their release time arrives.
+    const issueDateCutoff = await this.getEmployeeIssueDateCutoff(userContext)
+
     // Get distinct agent/vendor/issue_date combinations from paystubs
     let query = db
       .selectFrom('paystubs')
@@ -205,6 +214,11 @@ export class PayrollRepository {
           }
         }
       }
+
+      // Hide unreleased (future-dated) paystubs from non-admins
+      if (issueDateCutoff) {
+        query = query.where(db.fn('DATE', ['paystubs.issue_date']), '<=', issueDateCutoff)
+      }
     }
 
     // Apply additional filters
@@ -243,6 +257,11 @@ export class PayrollRepository {
         countQuery = countQuery.where('employees.id', 'in', userContext.managedEmployeeIds)
       } else if (userContext.employeeId) {
         countQuery = countQuery.where('employees.id', '=', userContext.employeeId)
+      }
+
+      // Hide unreleased (future-dated) paystubs from non-admins
+      if (issueDateCutoff) {
+        countQuery = countQuery.where(db.fn('DATE', ['paystubs.issue_date']), '<=', issueDateCutoff)
       }
     }
 
@@ -430,6 +449,13 @@ export class PayrollRepository {
       return null
     }
 
+    // Non-admins cannot view a paystub whose issue_date has not been released
+    // yet (e.g. before 8pm the day before payday).
+    const issueDateCutoff = await this.getEmployeeIssueDateCutoff(userContext)
+    if (issueDateCutoff && issueDate.slice(0, 10) > issueDateCutoff) {
+      return null
+    }
+
     // Get employee info
     const employee = await db
       .selectFrom('employees')
@@ -610,6 +636,12 @@ export class PayrollRepository {
         query = query.where('employees.id', '=', userContext.employeeId)
       } else {
         return []
+      }
+
+      // Hide unreleased (future-dated) paystubs from non-admins
+      const issueDateCutoff = await this.getEmployeeIssueDateCutoff(userContext)
+      if (issueDateCutoff) {
+        query = query.where(db.fn('DATE', ['paystubs.issue_date']), '<=', issueDateCutoff)
       }
     }
 
@@ -1117,6 +1149,38 @@ export class PayrollRepository {
     }
 
     return countsMap
+  }
+
+  /**
+   * Compute the latest paystub issue_date (inclusive, YYYY-MM-DD) that a
+   * non-admin user is currently allowed to see, based on the configured
+   * payroll release time. Used to hide future-dated paystubs that have been
+   * generated but not yet released (e.g. before 8pm the day before payday).
+   *
+   * Returns `null` for admins, who are never restricted.
+   */
+  private async getEmployeeIssueDateCutoff(userContext: {
+    isAdmin: boolean
+  }): Promise<string | null> {
+    if (userContext.isAdmin) return null
+
+    let release = { hour: DEFAULT_RELEASE_HOUR, minute: DEFAULT_RELEASE_MINUTE }
+    try {
+      const restriction = await db
+        .selectFrom('payroll_restriction')
+        .select(['hour', 'minute'])
+        .where('id', '=', 1)
+        .executeTakeFirst()
+
+      if (restriction) {
+        release = { hour: restriction.hour, minute: restriction.minute }
+      }
+    } catch (error) {
+      // Fall back to the secure default (8pm) rather than exposing paystubs.
+      logger.warn('Failed to load payroll_restriction, using default release time', error)
+    }
+
+    return getEmployeeVisibilityCutoff(release)
   }
 
   private hasEmployeeAccess(

--- a/src/lib/utils/__tests__/payroll-visibility.test.ts
+++ b/src/lib/utils/__tests__/payroll-visibility.test.ts
@@ -1,0 +1,94 @@
+import {
+  getEmployeeVisibilityCutoff,
+  isPaystubReleasedForEmployee,
+  toIssueDateString,
+  DEFAULT_RELEASE_HOUR,
+  DEFAULT_RELEASE_MINUTE,
+} from '@/lib/utils/payroll-visibility'
+
+/**
+ * Business rule under test:
+ * Pay day is Wednesday. A paystub dated for a given Wednesday is released to
+ * non-admins at 8:00pm (the configured restriction time) on the preceding
+ * Tuesday, evaluated in America/Detroit. Past paystubs are always visible;
+ * future ones stay hidden until their release moment.
+ */
+describe('payroll-visibility', () => {
+  const release = { hour: 20, minute: 0 } // 8:00pm
+
+  describe('getEmployeeVisibilityCutoff', () => {
+    it('defaults to 8:00pm when no release time provided', () => {
+      expect(DEFAULT_RELEASE_HOUR).toBe(20)
+      expect(DEFAULT_RELEASE_MINUTE).toBe(0)
+    })
+
+    it('keeps cutoff at today before the release time (EDT)', () => {
+      // Tue Jun 16 2026, 7:59pm Detroit (EDT, UTC-4) => 23:59Z
+      const now = new Date('2026-06-16T23:59:00Z')
+      expect(getEmployeeVisibilityCutoff(release, now)).toBe('2026-06-16')
+    })
+
+    it('advances cutoff to tomorrow at/after the release time (EDT)', () => {
+      // Tue Jun 16 2026, 8:00pm Detroit (EDT, UTC-4) => Jun 17 00:00Z
+      const now = new Date('2026-06-17T00:00:00Z')
+      expect(getEmployeeVisibilityCutoff(release, now)).toBe('2026-06-17')
+    })
+
+    it('handles standard time (EST, UTC-5) correctly', () => {
+      // Tue Jan 6 2026, 7:59pm Detroit (EST, UTC-5) => Jan 7 00:59Z -> cutoff today
+      expect(getEmployeeVisibilityCutoff(release, new Date('2026-01-07T00:59:00Z'))).toBe(
+        '2026-01-06'
+      )
+      // Tue Jan 6 2026, 8:00pm Detroit (EST, UTC-5) => Jan 7 01:00Z -> cutoff tomorrow
+      expect(getEmployeeVisibilityCutoff(release, new Date('2026-01-07T01:00:00Z'))).toBe(
+        '2026-01-07'
+      )
+    })
+  })
+
+  describe('isPaystubReleasedForEmployee', () => {
+    // Reference week: payday Wednesday Jun 17 2026.
+    const beforeRelease = new Date('2026-06-16T23:59:00Z') // Tue 7:59pm Detroit
+    const atRelease = new Date('2026-06-17T00:00:00Z') // Tue 8:00pm Detroit
+
+    it("hides this week's paystub before 8pm Tuesday", () => {
+      expect(isPaystubReleasedForEmployee('2026-06-17', release, beforeRelease)).toBe(false)
+    })
+
+    it("reveals this week's paystub at 8pm Tuesday", () => {
+      expect(isPaystubReleasedForEmployee('2026-06-17', release, atRelease)).toBe(true)
+    })
+
+    it('always shows past paystubs', () => {
+      expect(isPaystubReleasedForEmployee('2026-06-10', release, beforeRelease)).toBe(true)
+      expect(isPaystubReleasedForEmployee('2026-05-01', release, beforeRelease)).toBe(true)
+    })
+
+    it('hides next week and other future paystubs', () => {
+      // Even right after this week's release, next week's stays hidden
+      expect(isPaystubReleasedForEmployee('2026-06-24', release, atRelease)).toBe(false)
+      expect(isPaystubReleasedForEmployee('2026-07-01', release, atRelease)).toBe(false)
+    })
+
+    it("shows payday's paystub on payday morning (before 8pm)", () => {
+      // Wed Jun 17 2026, 9:00am Detroit => 13:00Z, before 8pm
+      const paydayMorning = new Date('2026-06-17T13:00:00Z')
+      expect(isPaystubReleasedForEmployee('2026-06-17', release, paydayMorning)).toBe(true)
+    })
+
+    it('accepts Date issue dates and ISO datetime strings', () => {
+      expect(isPaystubReleasedForEmployee(new Date('2026-06-17T00:00:00Z'), release, atRelease)).toBe(
+        true
+      )
+      expect(isPaystubReleasedForEmployee('2026-06-24T00:00:00.000Z', release, atRelease)).toBe(false)
+    })
+  })
+
+  describe('toIssueDateString', () => {
+    it('normalizes strings and dates to YYYY-MM-DD', () => {
+      expect(toIssueDateString('2026-06-17')).toBe('2026-06-17')
+      expect(toIssueDateString('2026-06-17T12:34:56.000Z')).toBe('2026-06-17')
+      expect(toIssueDateString(new Date('2026-06-17T00:00:00Z'))).toBe('2026-06-17')
+    })
+  })
+})

--- a/src/lib/utils/payroll-visibility.ts
+++ b/src/lib/utils/payroll-visibility.ts
@@ -1,0 +1,116 @@
+/**
+ * Paystub release / visibility rules for non-admin users.
+ *
+ * Business rule (ported from the legacy Laravel PaystubService):
+ * A paystub dated `issue_date` (payday, e.g. a Wednesday) is released to
+ * employees and managers at the configured restriction time on the day BEFORE
+ * the issue date (e.g. 8:00pm the preceding Tuesday). Before that moment the
+ * paystub must stay hidden from non-admins even though it has already been
+ * generated. Admins are never restricted.
+ *
+ * Expressed against "now", this reduces to a simple inclusive date cutoff:
+ *   - if the current local time is at/after the release time, paystubs dated up
+ *     to and including tomorrow are visible;
+ *   - otherwise only paystubs dated up to and including today are visible.
+ * Past-dated paystubs are therefore always visible, and future-dated ones stay
+ * hidden until their release moment arrives.
+ *
+ * Times are evaluated in the business timezone so behaviour is consistent
+ * regardless of where the server runs.
+ */
+
+/** Timezone the business operates in (matches the legacy app). */
+export const PAYROLL_TIMEZONE = 'America/Detroit'
+
+/** Defaults used when no payroll_restriction row is configured (8:00pm). */
+export const DEFAULT_RELEASE_HOUR = 20
+export const DEFAULT_RELEASE_MINUTE = 0
+
+export interface PayrollReleaseTime {
+  hour: number
+  minute: number
+}
+
+interface LocalDateParts {
+  /** Local calendar date in YYYY-MM-DD form. */
+  dateString: string
+  hour: number
+  minute: number
+}
+
+/**
+ * Extract the calendar date and time-of-day for an instant, evaluated in the
+ * given IANA timezone. Uses the built-in Intl API so no extra dependency or
+ * dayjs plugin is required.
+ */
+function getLocalDateParts(now: Date, timeZone: string): LocalDateParts {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  })
+
+  const parts = formatter.formatToParts(now)
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? '00'
+
+  return {
+    dateString: `${get('year')}-${get('month')}-${get('day')}`,
+    hour: parseInt(get('hour'), 10),
+    minute: parseInt(get('minute'), 10),
+  }
+}
+
+/**
+ * Add (or subtract) whole days to a YYYY-MM-DD date string without introducing
+ * timezone drift.
+ */
+function addDays(dateString: string, days: number): string {
+  const [year, month, day] = dateString.split('-').map(Number)
+  const dt = new Date(Date.UTC(year, month - 1, day))
+  dt.setUTCDate(dt.getUTCDate() + days)
+  return dt.toISOString().slice(0, 10)
+}
+
+/** Normalize an issue_date (string or Date) to a YYYY-MM-DD string. */
+export function toIssueDateString(issueDate: string | Date): string {
+  if (typeof issueDate === 'string') {
+    return issueDate.slice(0, 10)
+  }
+  // Mirror the rest of the codebase, which derives the date portion via ISO.
+  return issueDate.toISOString().slice(0, 10)
+}
+
+/**
+ * The latest paystub issue_date (inclusive, YYYY-MM-DD) that a non-admin user
+ * may currently see. Apply as `DATE(issue_date) <= cutoff` in queries, or
+ * compare directly against a single paystub's issue date.
+ */
+export function getEmployeeVisibilityCutoff(
+  release: PayrollReleaseTime = {
+    hour: DEFAULT_RELEASE_HOUR,
+    minute: DEFAULT_RELEASE_MINUTE,
+  },
+  now: Date = new Date()
+): string {
+  const { dateString, hour, minute } = getLocalDateParts(now, PAYROLL_TIMEZONE)
+  const released = hour * 60 + minute >= release.hour * 60 + release.minute
+  return released ? addDays(dateString, 1) : dateString
+}
+
+/**
+ * Whether a non-admin user may view a paystub with the given issue_date right
+ * now, based on the configured release time.
+ */
+export function isPaystubReleasedForEmployee(
+  issueDate: string | Date,
+  release?: PayrollReleaseTime,
+  now: Date = new Date()
+): boolean {
+  const cutoff = getEmployeeVisibilityCutoff(release, now)
+  return toIssueDateString(issueDate) <= cutoff
+}


### PR DESCRIPTION
Employees and managers could view paystubs dated in the future (any date
that had been generated for them), exposing pay data before it was meant
to be released. Pay day is Wednesday and a paystub should only become
visible to non-admins at the configured restriction time (default 8:00pm)
on the day before its issue date.

Restores the legacy release rule, evaluated in America/Detroit:
- past-dated paystubs are always visible
- a paystub dated D is released at (D - 1 day) at the restriction time,
  which reduces to an inclusive issue_date cutoff of today (or tomorrow
  once the release time has passed)
- admins are never restricted

Applies the cutoff across all non-admin read paths in PayrollRepository:
getPayrollSummary (list + count), getPaystubDetail, and
getAvailableIssueDates. The release time is read from payroll_restriction,
falling back to a secure 8:00pm default.

Adds payroll-visibility utility with unit tests covering EDT/EST,
the Tuesday 8pm boundary, payday, and future weeks.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NVvUrdd6q3jNt6SML7mkBx