### PR TITLE
fix: add year-range guardrails for payroll dates

### DIFF
--- a/src/app/api/admin/impersonate/start/__tests__/route.test.ts
+++ b/src/app/api/admin/impersonate/start/__tests__/route.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment node
+ */
+
+// ── Mocks (hoisted by jest) ─────────────────────────────────────────────────────
+const mockGetActiveImpersonation = jest.fn()
+const mockStartImpersonation = jest.fn()
+const mockStopImpersonation = jest.fn()
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}))
+
+jest.mock('@/lib/auth/config', () => ({
+  authOptions: {},
+}))
+
+jest.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: jest.fn().mockResolvedValue(true),
+}))
+
+jest.mock('@/lib/auth/impersonation-snapshot', () => ({
+  buildImpersonationSnapshot: jest.fn(),
+}))
+
+jest.mock('@/lib/repositories/ImpersonationRepository', () => ({
+  ImpersonationRepository: jest.fn().mockImplementation(() => ({
+    getActiveImpersonation: mockGetActiveImpersonation,
+    startImpersonation: mockStartImpersonation,
+    stopImpersonation: mockStopImpersonation,
+  })),
+}))
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────────
+import { POST } from '../route'
+import { getServerSession } from 'next-auth'
+import { buildImpersonationSnapshot } from '@/lib/auth/impersonation-snapshot'
+
+// ── Helpers ─────────────────────────────────────────────────────────────────────
+const actorId = 'admin-1'
+const targetId = 'target-1'
+
+const mockSession = {
+  user: { id: actorId, isSuperAdmin: true, isAdmin: true, isManager: false, employeeId: 5 },
+}
+
+function makeRequest(body: object = { targetUserId: targetId }) {
+  return new Request('http://localhost:3000/api/admin/impersonate/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as any
+}
+
+function buildSnapshot() {
+  ;(buildImpersonationSnapshot as jest.Mock).mockResolvedValue({
+    targetUserId: targetId,
+    targetEmployeeId: 9,
+    isSuperAdmin: false,
+    snapshot: { actAsUserId: targetId, targetName: 'Target' },
+  })
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────────
+describe('POST /api/admin/impersonate/start', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getServerSession as jest.Mock).mockResolvedValue(mockSession)
+    mockStartImpersonation.mockResolvedValue(1)
+    mockStopImpersonation.mockResolvedValue(1)
+    buildSnapshot()
+  })
+
+  it('returns 403 when caller is not a SuperAdmin', async () => {
+    ;(getServerSession as jest.Mock).mockResolvedValue({ user: { id: actorId, isSuperAdmin: false } })
+
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(403)
+  })
+
+  it('starts a session when no open row exists', async () => {
+    mockGetActiveImpersonation.mockResolvedValue(null)
+
+    const res = await POST(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(mockStartImpersonation).toHaveBeenCalledTimes(1)
+    expect(mockStopImpersonation).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when a live (non-expired) session is already open', async () => {
+    mockGetActiveImpersonation.mockResolvedValue({
+      id: 1,
+      actor_user_id: actorId,
+      expires_at: new Date(Date.now() + 10 * 60 * 1000), // 10 min in the future
+    })
+
+    const res = await POST(makeRequest())
+    const data = await res.json()
+
+    expect(res.status).toBe(409)
+    expect(data.error).toBe('An impersonation session is already open')
+    expect(mockStartImpersonation).not.toHaveBeenCalled()
+    expect(mockStopImpersonation).not.toHaveBeenCalled()
+  })
+
+  it('closes an expired orphan row and proceeds instead of blocking (THE BUG FIX)', async () => {
+    mockGetActiveImpersonation.mockResolvedValue({
+      id: 1,
+      actor_user_id: actorId,
+      expires_at: new Date(Date.now() - 60 * 1000), // expired 1 min ago
+    })
+
+    const res = await POST(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(mockStopImpersonation).toHaveBeenCalledWith(actorId, 'expired')
+    expect(mockStartImpersonation).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a null expires_at row as a closable orphan', async () => {
+    mockGetActiveImpersonation.mockResolvedValue({
+      id: 1,
+      actor_user_id: actorId,
+      expires_at: null,
+    })
+
+    const res = await POST(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(mockStopImpersonation).toHaveBeenCalledWith(actorId, 'expired')
+    expect(mockStartImpersonation).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/api/admin/impersonate/start/route.ts
+++ b/src/app/api/admin/impersonate/start/route.ts
@@ -57,10 +57,20 @@ export async function POST(request: NextRequest) {
   const repo = new ImpersonationRepository()
   const existing = await repo.getActiveImpersonation(session.user.id)
   if (existing) {
-    return NextResponse.json(
-      { error: 'An impersonation session is already open' },
-      { status: 409 }
-    )
+    // A timed-out session is auto-cleared from the JWT on refresh, but nothing
+    // writes the expiry back to the DB — so the audit row leaks as "open" and
+    // would block every future session. If the open row is past its TTL, close
+    // it as expired and proceed; only a genuinely live session returns 409.
+    const expired =
+      !existing.expires_at || existing.expires_at.getTime() < Date.now()
+    if (expired) {
+      await repo.stopImpersonation(session.user.id, 'expired')
+    } else {
+      return NextResponse.json(
+        { error: 'An impersonation session is already open' },
+        { status: 409 }
+      )
+    }
   }
 
   const ip =

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -5,6 +5,10 @@ import { invoiceRepository } from '@/lib/repositories/InvoiceRepository.simple'
 import { getEmployeeContext } from '@/lib/auth/payroll-access'
 import { PayrollRepository } from '@/lib/repositories/PayrollRepository'
 import { logger } from '@/lib/utils/logger'
+import {
+  assertPayrollDateInRange,
+  PayrollDateRangeError,
+} from '@/lib/utils/dateValidation'
 
 /**
  * GET /api/invoices - Get invoice page resources or invoice details
@@ -103,6 +107,34 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json()
     logger.log('📝 Request body received')
+
+    // Authoritative date-range validation BEFORE any DB write / audit /
+    // recalculation (criteria A1–A9, A8). Out-of-range dates are rejected with
+    // a 400 and an actionable, machine-readable body. Nothing is persisted.
+    try {
+      assertPayrollDateInRange(body?.issueDate, 'issueDate')
+      assertPayrollDateInRange(body?.weekending, 'weekending')
+
+      if (Array.isArray(body?.sales)) {
+        body.sales.forEach((sale: { sale_date?: string }, index: number) => {
+          assertPayrollDateInRange(sale?.sale_date, `sales[${index}].sale_date`)
+        })
+      }
+    } catch (validationError) {
+      if (validationError instanceof PayrollDateRangeError) {
+        logger.warn('🚫 Rejected out-of-range payroll date:', validationError.message)
+        return NextResponse.json(
+          {
+            success: false,
+            error: validationError.message,
+            field: validationError.field,
+            allowedRange: validationError.range,
+          },
+          { status: 400 }
+        )
+      }
+      throw validationError
+    }
 
     // Add audit metadata
     const requestWithAudit = {

--- a/src/components/invoice/InvoiceEditor.tsx
+++ b/src/components/invoice/InvoiceEditor.tsx
@@ -19,6 +19,13 @@ import InvoiceOverridesTable from './InvoiceOverridesTable';
 import InvoiceExpensesTable from './InvoiceExpensesTable';
 import { formatCurrency } from '@/lib/utils';
 import { logger } from '@/lib/utils/logger'
+import {
+  MIN_PAYROLL_YEAR,
+  maxPayrollYear,
+  extractYear,
+  isYearInRange,
+  allowedRangeLabel,
+} from '@/lib/utils/dateValidation'
 
 interface InvoiceEditorProps {
   mode: 'create' | 'edit';
@@ -53,7 +60,7 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
     vendor: '',
     agentId: agentId || 0,
     issueDate: issueDate || '',
-    weekending: initialData?.weekending ? dayjs(initialData.weekending, 'MM-DD-YYYY').format('yyyy-MM-dd') : '',
+    weekending: initialData?.weekending ? dayjs(initialData.weekending, 'MM-DD-YYYY').format('YYYY-MM-DD') : '',
     sales: [],
     overrides: [],
     expenses: []
@@ -78,6 +85,11 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
   const [totalAmount, setTotalAmount] = useState(0);
   const [showCustomDateDialog, setShowCustomDateDialog] = useState(false);
   const [customDateValue, setCustomDateValue] = useState('');
+  const [customDateError, setCustomDateError] = useState('');
+
+  // Shared date-input bounds (single source of truth — same range as server/importer).
+  const dateInputMin = `${MIN_PAYROLL_YEAR}-01-01`;
+  const dateInputMax = `${maxPayrollYear()}-12-31`;
 
   // Fetch vendor-specific custom field definitions (feature-flag gated)
   const { fields: vendorFields, isConfigured: isVendorConfigured, isLoading: isVendorFieldsLoading } = useVendorFields(
@@ -290,6 +302,7 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
       // Open custom date dialog
       setShowCustomDateDialog(true);
       setCustomDateValue('');
+      setCustomDateError('');
     } else {
       // Use selected existing date
       setFormData(prev => ({ ...prev, issueDate: value }));
@@ -297,18 +310,30 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
   };
 
   const handleCustomDateConfirm = () => {
-    if (customDateValue) {
-      // Convert from yyyy-MM-dd to MM/DD/YYYY for consistency
-      const formatted = dayjs(customDateValue).format('MM/DD/YYYY');
-      setFormData(prev => ({ ...prev, issueDate: formatted }));
-      setShowCustomDateDialog(false);
-      setCustomDateValue('');
+    if (!customDateValue) {
+      return;
     }
+
+    // Guardrail: reject out-of-range years (e.g. the 2926 typo). Keep the dialog
+    // open and surface an inline error so the user can correct it (criterion B1).
+    const year = extractYear(customDateValue);
+    if (year === null || !isYearInRange(year)) {
+      setCustomDateError(`Issue date year must be within ${allowedRangeLabel()}.`);
+      return;
+    }
+
+    // Convert from YYYY-MM-DD to MM/DD/YYYY for consistency.
+    const formatted = dayjs(customDateValue, 'YYYY-MM-DD').format('MM/DD/YYYY');
+    setFormData(prev => ({ ...prev, issueDate: formatted }));
+    setShowCustomDateDialog(false);
+    setCustomDateValue('');
+    setCustomDateError('');
   };
 
   const handleCustomDateCancel = () => {
     setShowCustomDateDialog(false);
     setCustomDateValue('');
+    setCustomDateError('');
   };
 
   const handleSalesChange = (sales: InvoiceSaleFormData[]) => {
@@ -405,6 +430,29 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
         toast({
           title: 'Validation Error',
           description: 'Please select a weekending date',
+          variant: 'destructive'
+        });
+        return;
+      }
+
+      // Year-range guardrail (criterion B4). Blocks out-of-range issueDate /
+      // weekending (including values pasted into the date inputs) before any
+      // network request. The server re-validates authoritatively (Area A).
+      const issueYear = extractYear(formData.issueDate);
+      if (issueYear === null || !isYearInRange(issueYear)) {
+        toast({
+          title: 'Validation Error',
+          description: `Issue date year must be within ${allowedRangeLabel()}.`,
+          variant: 'destructive'
+        });
+        return;
+      }
+
+      const weekendingYear = extractYear(formData.weekending);
+      if (weekendingYear === null || !isYearInRange(weekendingYear)) {
+        toast({
+          title: 'Validation Error',
+          description: `Weekending date year must be within ${allowedRangeLabel()}.`,
           variant: 'destructive'
         });
         return;
@@ -514,17 +562,32 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
                   <SelectValue placeholder="Select issue date" />
                 </SelectTrigger>
                 <SelectContent>
-                  {/* Show custom date if it's not in the existing dates list */}
-                  {formData.issueDate && !issueDates.includes(formData.issueDate) && (
-                    <SelectItem key={formData.issueDate} value={formData.issueDate}>
-                      {formData.issueDate}
-                    </SelectItem>
-                  )}
-                  {issueDates.map(date => (
-                    <SelectItem key={date} value={date}>
-                      {dayjs(date).format('MM/DD/YYYY')}
-                    </SelectItem>
-                  ))}
+                  {/* Escape hatch (edit mode): show the current value if it is not
+                      in the fetched list — but NEVER inject an out-of-range value
+                      so a previously-saved bad date (e.g. 2926) cannot be
+                      re-selected (criterion C3/C4). */}
+                  {formData.issueDate &&
+                    !issueDates.includes(formData.issueDate) &&
+                    (() => {
+                      const y = extractYear(formData.issueDate);
+                      return y !== null && isYearInRange(y);
+                    })() && (
+                      <SelectItem key={formData.issueDate} value={formData.issueDate}>
+                        {formData.issueDate}
+                      </SelectItem>
+                    )}
+                  {/* Filter out-of-range values from the rendered options so a bad
+                      DB value can never be selected from the dropdown (C1/C4). */}
+                  {issueDates
+                    .filter(date => {
+                      const y = extractYear(date);
+                      return y !== null && isYearInRange(y);
+                    })
+                    .map(date => (
+                      <SelectItem key={date} value={date}>
+                        {dayjs(date).format('MM/DD/YYYY')}
+                      </SelectItem>
+                    ))}
                   <SelectItem value="__CUSTOM__" className="font-medium text-primary">
                     Custom Date...
                   </SelectItem>
@@ -538,6 +601,8 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
               </Label>
               <Input
                 type="date"
+                min={dateInputMin}
+                max={dateInputMax}
                 value={formData.weekending}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFormData(prev => ({ ...prev, weekending: e.target.value }))}
                 required
@@ -621,10 +686,18 @@ export default function InvoiceEditor({ mode, agentId, vendorId, issueDate, init
             <Input
               id="customDate"
               type="date"
+              min={dateInputMin}
+              max={dateInputMax}
               value={customDateValue}
-              onChange={(e) => setCustomDateValue(e.target.value)}
+              onChange={(e) => {
+                setCustomDateValue(e.target.value);
+                if (customDateError) setCustomDateError('');
+              }}
               className="mt-2"
             />
+            {customDateError && (
+              <p className="mt-2 text-sm text-destructive">{customDateError}</p>
+            )}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={handleCustomDateCancel}>

--- a/src/lib/excel-import/__tests__/parser-date-guardrails.test.ts
+++ b/src/lib/excel-import/__tests__/parser-date-guardrails.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Area D: Excel importer year-range guardrails.
+ *
+ * Verifies that `validateAndFormatRow` (which delegates date handling to the
+ * internal `validateAndFormatDate`) rejects out-of-range years from ISO strings,
+ * US strings, and Excel serial numbers, while still importing valid dates to
+ * YYYY-MM-DD. The accept/reject decisions must match the shared range used by
+ * the server and client (criterion D4) — we assert that by deriving the boundary
+ * years from the same `maxPayrollYear()` helper.
+ */
+
+import * as XLSX from 'xlsx'
+import { validateAndFormatRow, setDateFormat } from '../parser'
+import { MIN_PAYROLL_YEAR, maxPayrollYear } from '@/lib/utils/dateValidation'
+
+const MAX_YEAR = maxPayrollYear()
+
+/** Build a minimal valid row, overriding sale_date. Single mode keeps it lean. */
+function rowWith(saleDate: unknown): Record<string, unknown> {
+  return {
+    sale_date: saleDate,
+    first_name: 'Jane',
+    last_name: 'Doe',
+    status: 'sold',
+    amount: 100,
+  }
+}
+
+/** Excel serial number for a given calendar date (1900 date system). */
+function excelSerial(year: number, month: number, day: number): number {
+  // XLSX exposes the inverse of parse_date_code via datenum on the SSF table.
+  // Fall back to a manual computation if not present.
+  const ssf = XLSX.SSF as unknown as {
+    parse_date_code: (n: number) => { y: number; m: number; d: number } | null
+  }
+  // Binary-free approach: days since 1899-12-30 (Excel epoch).
+  const epoch = Date.UTC(1899, 11, 30)
+  const target = Date.UTC(year, month - 1, day)
+  const serial = Math.round((target - epoch) / 86400000)
+  // Sanity check round-trips through the same lib the parser uses.
+  const parsed = ssf.parse_date_code(serial)
+  expect(parsed).toMatchObject({ y: year, m: month, d: day })
+  return serial
+}
+
+beforeEach(() => {
+  setDateFormat('auto')
+})
+
+describe('validateAndFormatRow — date year range (Area D)', () => {
+  it('D3: valid ISO date imports to YYYY-MM-DD', () => {
+    const result = validateAndFormatRow(rowWith('2026-06-24'), 1, true)
+    expect(result.valid).toBe(true)
+    expect(result.formatted.sale_date).toBe('2026-06-24')
+  })
+
+  it('D3: valid US date imports to YYYY-MM-DD', () => {
+    setDateFormat('US')
+    const result = validateAndFormatRow(rowWith('06/24/2026'), 1, true)
+    expect(result.valid).toBe(true)
+    expect(result.formatted.sale_date).toBe('2026-06-24')
+  })
+
+  it('D3: valid Excel serial imports to YYYY-MM-DD', () => {
+    const serial = excelSerial(2025, 9, 7)
+    const result = validateAndFormatRow(rowWith(serial), 1, true)
+    expect(result.valid).toBe(true)
+    expect(result.formatted.sale_date).toBe('2025-09-07')
+  })
+
+  it('D1: year 2926 (the incident) is rejected with a range-naming error', () => {
+    const result = validateAndFormatRow(rowWith('2926-06-24'), 5, true)
+    expect(result.valid).toBe(false)
+    const err = result.errors.find(e => e.field === 'sale_date')
+    expect(err).toBeDefined()
+    expect(err!.row).toBe(5)
+    expect(err!.message).toContain(`${MIN_PAYROLL_YEAR}`)
+    expect(err!.message).toContain(`${MAX_YEAR}`)
+    expect(result.formatted.sale_date).toBeUndefined()
+  })
+
+  it.each([
+    ['1899-12-31', 1899],
+    ['9999-01-01', 9999],
+    ['1999-12-31', 1999],
+  ])('D1: out-of-range %s rejected', (input) => {
+    const result = validateAndFormatRow(rowWith(input), 2, true)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.field === 'sale_date')).toBe(true)
+  })
+
+  it('A7 boundary: 2000 accepted', () => {
+    const result = validateAndFormatRow(rowWith('2000-01-01'), 1, true)
+    expect(result.valid).toBe(true)
+    expect(result.formatted.sale_date).toBe('2000-01-01')
+  })
+
+  it('A5 boundary: Y+1 accepted', () => {
+    const result = validateAndFormatRow(rowWith(`${MAX_YEAR}-12-31`), 1, true)
+    expect(result.valid).toBe(true)
+    expect(result.formatted.sale_date).toBe(`${MAX_YEAR}-12-31`)
+  })
+
+  it('A6 boundary: Y+2 rejected', () => {
+    const result = validateAndFormatRow(rowWith(`${MAX_YEAR + 1}-01-01`), 1, true)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.field === 'sale_date')).toBe(true)
+  })
+
+  it('D2: mis-mapped numeric column resolving to a far-future year is rejected', () => {
+    // A large serial that lands well past Y+1 (e.g. year ~9999).
+    const serial = excelSerial(9999, 1, 1)
+    const result = validateAndFormatRow(rowWith(serial), 7, true)
+    expect(result.valid).toBe(false)
+    const err = result.errors.find(e => e.field === 'sale_date')
+    expect(err).toBeDefined()
+    expect(err!.message).toContain(`${MAX_YEAR}`)
+  })
+
+  it('E1: leap day 2024-02-29 accepted and not mangled', () => {
+    const result = validateAndFormatRow(rowWith('2024-02-29'), 1, true)
+    expect(result.valid).toBe(true)
+    expect(result.formatted.sale_date).toBe('2024-02-29')
+  })
+
+  it('E2: empty sale_date falls through to required-field error (range check does not throw)', () => {
+    const result = validateAndFormatRow(rowWith(''), 1, true)
+    expect(result.valid).toBe(false)
+    const err = result.errors.find(e => e.field === 'sale_date')
+    expect(err!.message).toContain('required')
+  })
+})

--- a/src/lib/excel-import/parser.ts
+++ b/src/lib/excel-import/parser.ts
@@ -6,6 +6,7 @@ import * as XLSX from 'xlsx';
 import Papa from 'papaparse';
 import { ColumnMapping } from './field-mapper';
 import { logger } from '@/lib/utils/logger'
+import { isYearInRange, allowedRangeLabel } from '@/lib/utils/dateValidation'
 
 export interface ParsedData {
   headers: string[];
@@ -654,6 +655,21 @@ function validateAndFormatDate(
             globalDateFormat === 'ISO' ? 'YYYY-MM-DD' :
             'MM/DD/YYYY or YYYY-MM-DD'
           }. Received: ${typeof value === 'string' || typeof value === 'number' ? value : typeof value}`
+        }
+      };
+    }
+
+    // Year-range guardrail (criteria D1/D2/D4) — same shared range as the
+    // server and client so import accept/reject decisions never drift. Rejects
+    // typo'd years (e.g. 2926) and mis-mapped numeric columns resolving to a
+    // far-future/past year. Row is marked invalid, not silently imported.
+    if (!isYearInRange(date.getFullYear())) {
+      return {
+        error: {
+          row: rowNumber,
+          field,
+          value,
+          message: `Date for ${field} has a year (${date.getFullYear()}) outside the allowed range ${allowedRangeLabel()}. Received: ${typeof value === 'string' || typeof value === 'number' ? value : typeof value}`
         }
       };
     }

--- a/src/lib/repositories/InvoiceRepository.simple.ts
+++ b/src/lib/repositories/InvoiceRepository.simple.ts
@@ -2,6 +2,7 @@ import { db } from '@/lib/database/client'
 import dayjs from 'dayjs'
 import { invoiceAuditRepository } from './InvoiceAuditRepository'
 import { logger } from '@/lib/utils/logger'
+import { assertPayrollDateInRange } from '@/lib/utils/dateValidation'
 import type { UserContext } from '@/lib/auth/types'
 
 // Simple types for our gradual implementation
@@ -79,6 +80,18 @@ export class InvoiceRepository {
       if (!userContext.managedEmployeeIds?.includes(request.agentId)) {
         throw new Error('Access denied: agent not in your direct reports')
       }
+    }
+
+    // Defense-in-depth date guardrail (criterion A backstop). Protects every
+    // caller, including any non-HTTP path that bypasses the API route, from
+    // persisting out-of-range years. Throws PayrollDateRangeError before any
+    // write occurs. customParseFormat is NOT loaded, so the later
+    // dayjs(x, 'FORMAT') calls fall back to native parsing — we cannot rely on
+    // them to reject bad input, hence this explicit guard.
+    assertPayrollDateInRange(request.issueDate, 'issueDate')
+    assertPayrollDateInRange(request.weekending, 'weekending')
+    for (let i = 0; i < (request.sales?.length || 0); i++) {
+      assertPayrollDateInRange(request.sales[i]?.sale_date, `sales[${i}].sale_date`)
     }
 
     logger.log('🚀 Starting SIMPLE saveInvoiceData with transaction')

--- a/src/lib/repositories/__tests__/InvoiceRepository.dateGuard.test.ts
+++ b/src/lib/repositories/__tests__/InvoiceRepository.dateGuard.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Area A backstop: the InvoiceRepository date-range guard.
+ *
+ * Verifies that `saveInvoiceData` rejects out-of-range years BEFORE any DB write
+ * (criterion A8) — protecting non-HTTP callers that bypass the API route. We
+ * mock the database client so any accidental write would be observable, then
+ * assert `db.transaction` was never reached when a bad date is supplied.
+ */
+
+import type { UserContext } from '@/lib/auth/types'
+import { PayrollDateRangeError, maxPayrollYear } from '@/lib/utils/dateValidation'
+
+const transactionExecute = jest.fn().mockResolvedValue({
+  salesResults: [],
+  overrideResults: [],
+  expenseResults: [],
+  deletedSales: [],
+})
+
+const mockDb = {
+  transaction: jest.fn().mockReturnValue({ execute: transactionExecute }),
+  selectFrom: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  executeTakeFirst: jest.fn().mockResolvedValue(null),
+  insertInto: jest.fn().mockReturnThis(),
+  values: jest.fn().mockReturnThis(),
+  updateTable: jest.fn().mockReturnThis(),
+  set: jest.fn().mockReturnThis(),
+  execute: jest.fn().mockResolvedValue([]),
+}
+
+jest.mock('@/lib/database/client', () => ({ db: mockDb }))
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}))
+
+jest.mock('../InvoiceAuditRepository', () => ({
+  invoiceAuditRepository: { createAuditRecord: jest.fn().mockResolvedValue(undefined) },
+}))
+
+// Lazily required after mocks are registered (jest hoists jest.mock above
+// imports; a top-level import of the repo would bind the real db client).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { invoiceRepository } = require('../InvoiceRepository.simple')
+
+const adminCtx: UserContext = { employeeId: 1, isAdmin: true, isManager: false }
+const MAX_YEAR = maxPayrollYear()
+
+function baseRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    vendor: '1',
+    agentId: 10,
+    issueDate: '2026-06-24',
+    weekending: '2026-06-20',
+    sales: [
+      {
+        sale_date: '2026-06-18',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        address: '1 Main',
+        city: 'Town',
+        status: 'sold',
+        amount: 100,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('InvoiceRepository.saveInvoiceData date guard (Area A backstop)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDb.transaction.mockReturnValue({ execute: transactionExecute })
+  })
+
+  it('A1/A8: rejects out-of-range issueDate before any DB write', async () => {
+    await expect(
+      invoiceRepository.saveInvoiceData(baseRequest({ issueDate: '2926-06-24' }) as never, adminCtx)
+    ).rejects.toBeInstanceOf(PayrollDateRangeError)
+    expect(mockDb.transaction).not.toHaveBeenCalled()
+  })
+
+  it('A2: rejects out-of-range weekending before any DB write', async () => {
+    await expect(
+      invoiceRepository.saveInvoiceData(baseRequest({ weekending: '1899-01-01' }) as never, adminCtx)
+    ).rejects.toBeInstanceOf(PayrollDateRangeError)
+    expect(mockDb.transaction).not.toHaveBeenCalled()
+  })
+
+  it('A3: rejects an out-of-range sale_date and names the failing row', async () => {
+    const req = baseRequest({
+      sales: [
+        {
+          sale_date: '9999-01-01',
+          first_name: 'A',
+          last_name: 'B',
+          address: 'x',
+          city: 'y',
+          status: 'sold',
+          amount: 1,
+        },
+      ],
+    })
+    await expect(
+      invoiceRepository.saveInvoiceData(req as never, adminCtx)
+    ).rejects.toMatchObject({ field: 'sales[0].sale_date' })
+    expect(mockDb.transaction).not.toHaveBeenCalled()
+  })
+
+  it('A6: rejects Y+2', async () => {
+    await expect(
+      invoiceRepository.saveInvoiceData(
+        baseRequest({ issueDate: `${MAX_YEAR + 1}-01-01` }) as never,
+        adminCtx
+      )
+    ).rejects.toBeInstanceOf(PayrollDateRangeError)
+    expect(mockDb.transaction).not.toHaveBeenCalled()
+  })
+
+  it('R1: in-range request passes the guard and reaches the transaction', async () => {
+    await invoiceRepository.saveInvoiceData(baseRequest() as never, adminCtx)
+    expect(mockDb.transaction).toHaveBeenCalled()
+  })
+})

--- a/src/lib/utils/__tests__/dateValidation.test.ts
+++ b/src/lib/utils/__tests__/dateValidation.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the shared payroll date year-range guardrail.
+ *
+ * These guard against the 2926-style production incident where an out-of-range
+ * year was accepted and corrupted hundreds of records. The allowed range is
+ * 2000 <= year <= currentYear + 1. Bounds are derived from `new Date()` in the
+ * tests too (and a fixed clock is injected where boundaries matter) so the suite
+ * does not become brittle as calendar years roll over.
+ */
+
+import {
+  MIN_PAYROLL_YEAR,
+  maxPayrollYear,
+  isYearInRange,
+  extractYear,
+  isEmptyDateInput,
+  assertPayrollDateInRange,
+  PayrollDateRangeError,
+  allowedRange,
+  allowedRangeLabel,
+} from '../dateValidation'
+
+// Deterministic clock: pretend "now" is 2026-06-24 → max year = 2027.
+const FIXED_NOW = new Date('2026-06-24T12:00:00Z')
+const FIXED_MAX = 2027
+
+describe('range bounds', () => {
+  it('MIN_PAYROLL_YEAR is 2000', () => {
+    expect(MIN_PAYROLL_YEAR).toBe(2000)
+  })
+
+  it('maxPayrollYear is currentYear + 1', () => {
+    expect(maxPayrollYear(FIXED_NOW)).toBe(FIXED_MAX)
+    // Derive from a live clock too, so the contract holds regardless of year.
+    expect(maxPayrollYear()).toBe(new Date().getFullYear() + 1)
+  })
+
+  it('allowedRange / allowedRangeLabel expose the bounds', () => {
+    expect(allowedRange(FIXED_NOW)).toEqual({ min: 2000, max: FIXED_MAX })
+    expect(allowedRangeLabel(FIXED_NOW)).toBe('2000–2027')
+  })
+})
+
+describe('isYearInRange', () => {
+  it.each([
+    [2000, true], // A7 lower boundary
+    [1999, false], // A7 just below
+    [2026, true],
+    [FIXED_MAX, true], // A5 upper boundary Y+1
+    [FIXED_MAX + 1, false], // A6 Y+2 rejected
+    [2926, false], // the incident
+    [1899, false],
+    [9999, false],
+    [1000, false],
+    [226, false], // "0226"
+    [0, false],
+  ])('year %i → %s', (year, expected) => {
+    expect(isYearInRange(year, FIXED_NOW)).toBe(expected)
+  })
+
+  it('rejects non-integers and NaN without throwing', () => {
+    expect(isYearInRange(NaN, FIXED_NOW)).toBe(false)
+    expect(isYearInRange(2026.5, FIXED_NOW)).toBe(false)
+  })
+})
+
+describe('extractYear', () => {
+  it('parses ISO YYYY-MM-DD', () => {
+    expect(extractYear('2026-06-24')).toBe(2026)
+    expect(extractYear('2926-06-24')).toBe(2926)
+  })
+
+  it('parses ISO with a time component', () => {
+    expect(extractYear('2026-06-24T00:00:00Z')).toBe(2026)
+  })
+
+  it('parses US MM/DD/YYYY and MM-DD-YYYY', () => {
+    expect(extractYear('06/24/2026')).toBe(2026)
+    expect(extractYear('06-24-2026')).toBe(2026) // dropdown format
+  })
+
+  it('reads year from a Date object', () => {
+    expect(extractYear(new Date('2026-06-24T12:00:00Z'))).toBe(2026)
+  })
+
+  it('returns null for empty / nullish', () => {
+    expect(extractYear('')).toBeNull()
+    expect(extractYear('   ')).toBeNull()
+    expect(extractYear(null)).toBeNull()
+    expect(extractYear(undefined)).toBeNull()
+  })
+
+  it('returns null for invalid Date objects', () => {
+    expect(extractYear(new Date('not a date'))).toBeNull()
+  })
+
+  it('rejects malformed / two-digit years rather than coercing them (E3)', () => {
+    expect(extractYear('26-06-24')).toBeNull()
+    expect(extractYear('0226-06-24')).toBe(226) // 4-digit but out of range → caught by isYearInRange
+    expect(extractYear('garbage')).toBeNull()
+    expect(extractYear('24/06')).toBeNull()
+  })
+
+  it('preserves leap day without mangling (E1)', () => {
+    expect(extractYear('2024-02-29')).toBe(2024)
+  })
+})
+
+describe('isEmptyDateInput', () => {
+  it('treats null/undefined/blank as empty, real values as non-empty', () => {
+    expect(isEmptyDateInput(null)).toBe(true)
+    expect(isEmptyDateInput(undefined)).toBe(true)
+    expect(isEmptyDateInput('')).toBe(true)
+    expect(isEmptyDateInput('  ')).toBe(true)
+    expect(isEmptyDateInput('2026-06-24')).toBe(false)
+    expect(isEmptyDateInput(new Date())).toBe(false)
+  })
+})
+
+describe('assertPayrollDateInRange', () => {
+  it('is a no-op for in-range dates', () => {
+    expect(() => assertPayrollDateInRange('2026-06-24', 'issueDate', FIXED_NOW)).not.toThrow()
+    expect(() => assertPayrollDateInRange('2000-01-01', 'issueDate', FIXED_NOW)).not.toThrow()
+    expect(() => assertPayrollDateInRange(`${FIXED_MAX}-12-31`, 'issueDate', FIXED_NOW)).not.toThrow()
+  })
+
+  it('is a no-op for empty input — required-field logic owns that (E2/B6)', () => {
+    expect(() => assertPayrollDateInRange('', 'issueDate', FIXED_NOW)).not.toThrow()
+    expect(() => assertPayrollDateInRange(null, 'issueDate', FIXED_NOW)).not.toThrow()
+    expect(() => assertPayrollDateInRange(undefined, 'issueDate', FIXED_NOW)).not.toThrow()
+  })
+
+  it('throws PayrollDateRangeError for out-of-range years', () => {
+    expect(() => assertPayrollDateInRange('2926-06-24', 'issueDate', FIXED_NOW)).toThrow(
+      PayrollDateRangeError
+    )
+    expect(() => assertPayrollDateInRange('1899-06-24', 'weekending', FIXED_NOW)).toThrow(
+      PayrollDateRangeError
+    )
+    expect(() => assertPayrollDateInRange(`${FIXED_MAX + 1}-01-01`, 'issueDate', FIXED_NOW)).toThrow(
+      PayrollDateRangeError
+    )
+    expect(() => assertPayrollDateInRange('1999-12-31', 'issueDate', FIXED_NOW)).toThrow(
+      PayrollDateRangeError
+    )
+  })
+
+  it('throws for malformed non-empty input (E3)', () => {
+    expect(() => assertPayrollDateInRange('26-06-24', 'issueDate', FIXED_NOW)).toThrow(
+      PayrollDateRangeError
+    )
+  })
+
+  it('error carries actionable field + range metadata (A9)', () => {
+    try {
+      assertPayrollDateInRange('2926-06-24', 'sales[3].sale_date', FIXED_NOW)
+      throw new Error('expected to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(PayrollDateRangeError)
+      const e = err as PayrollDateRangeError
+      expect(e.field).toBe('sales[3].sale_date')
+      expect(e.year).toBe(2926)
+      expect(e.range).toEqual({ min: 2000, max: FIXED_MAX })
+      expect(e.message).toContain('2000–2027')
+    }
+  })
+})

--- a/src/lib/utils/dateValidation.ts
+++ b/src/lib/utils/dateValidation.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared payroll date year-range guardrails.
+ *
+ * Single source of truth (acceptance criterion E4) consumed by:
+ *  - the invoice client form (InvoiceEditor)
+ *  - the authoritative server route (POST /api/invoices)
+ *  - the invoice repository (defense-in-depth backstop)
+ *  - the Excel/CSV importer (validateAndFormatDate)
+ *
+ * Background: a production incident occurred when an issue date year was
+ * mistyped as 2926 instead of 2026. It was accepted with zero validation,
+ * re-selected from a dropdown across an entire pay run, and corrupted ~333
+ * invoices plus related paystubs/overrides/expenses/payroll rows.
+ *
+ * Allowed range: 2000 <= year <= currentYear + 1 (inclusive).
+ *  - Lower bound 2000: no legitimate payroll predates it; rejects 2-digit fat-fingers.
+ *  - Upper bound currentYear+1: covers entering an upcoming pay period that crosses
+ *    a year boundary in late December; +2 and beyond is the typo class (2926).
+ */
+
+/** Inclusive lower bound for any payroll-related date year. */
+export const MIN_PAYROLL_YEAR = 2000
+
+/**
+ * Inclusive upper bound for any payroll-related date year.
+ * Derived from the system clock so it never needs a code change as years roll over.
+ */
+export function maxPayrollYear(now: Date = new Date()): number {
+  return now.getFullYear() + 1
+}
+
+/** True when `year` is a finite integer within [MIN_PAYROLL_YEAR, maxPayrollYear()]. */
+export function isYearInRange(year: number, now: Date = new Date()): boolean {
+  if (!Number.isInteger(year)) {
+    return false
+  }
+  return year >= MIN_PAYROLL_YEAR && year <= maxPayrollYear(now)
+}
+
+/**
+ * Human-readable description of the allowed range, e.g. "2000–2027".
+ * Used in error messages so the user knows exactly what is acceptable.
+ */
+export function allowedRangeLabel(now: Date = new Date()): string {
+  return `${MIN_PAYROLL_YEAR}–${maxPayrollYear(now)}`
+}
+
+/**
+ * Machine-readable allowed-range descriptor for API error bodies (criterion A9).
+ */
+export function allowedRange(now: Date = new Date()): { min: number; max: number } {
+  return { min: MIN_PAYROLL_YEAR, max: maxPayrollYear(now) }
+}
+
+/**
+ * Error thrown by {@link assertPayrollDateInRange} when a date's year is out of range.
+ * Typed so callers (e.g. the API route) can distinguish a guardrail rejection from
+ * an unexpected failure and translate it into a 400 response.
+ */
+export class PayrollDateRangeError extends Error {
+  readonly field: string
+  readonly year: number | null
+  readonly range: { min: number; max: number }
+
+  constructor(field: string, year: number | null, now: Date = new Date()) {
+    const range = allowedRange(now)
+    const yearText = year === null ? 'an unparseable value' : `year ${year}`
+    super(
+      `Invalid ${field}: ${yearText} is outside the allowed payroll range ${range.min}–${range.max}.`
+    )
+    this.name = 'PayrollDateRangeError'
+    this.field = field
+    this.year = year
+    this.range = range
+  }
+}
+
+/**
+ * Extract a 4-digit year from a Date or a date string without relying on
+ * locale-dependent native Date parsing (which silently coerces malformed input).
+ *
+ * Accepts:
+ *  - `Date` objects (uses local getFullYear)
+ *  - ISO-ish `YYYY-MM-DD` (optionally with a time component) strings
+ *  - `MM/DD/YYYY` and `MM-DD-YYYY` strings (the formats used across this app)
+ *
+ * Returns `null` when no unambiguous 4-digit year can be extracted. Callers that
+ * need to reject malformed input should treat `null` as out-of-range; callers
+ * that allow empty/undefined values (required-field logic owns that) should
+ * skip the check when the input is empty (see {@link assertPayrollDateInRange}).
+ */
+export function extractYear(dateInput: Date | string | null | undefined): number | null {
+  if (dateInput == null) {
+    return null
+  }
+
+  if (dateInput instanceof Date) {
+    return Number.isNaN(dateInput.getTime()) ? null : dateInput.getFullYear()
+  }
+
+  const trimmed = String(dateInput).trim()
+  if (trimmed === '') {
+    return null
+  }
+
+  // ISO form: YYYY-MM-DD or YYYY-MM-DDThh:mm... — year must be exactly 4 digits.
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T ].*)?$/)
+  if (isoMatch) {
+    return parseInt(isoMatch[1], 10)
+  }
+
+  // US form: MM/DD/YYYY or MM-DD-YYYY — year must be exactly 4 digits.
+  const usMatch = trimmed.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{4})$/)
+  if (usMatch) {
+    return parseInt(usMatch[3], 10)
+  }
+
+  // Anything else (2-digit years, "26-06-24", "0226-06-24" with non-4-digit year,
+  // free text) is intentionally rejected rather than coerced (criterion E3).
+  return null
+}
+
+/**
+ * Returns true when the input is empty (null/undefined/blank string) and therefore
+ * should be deferred to required-field validation rather than the range check
+ * (criteria B6 / E2 — the range check must not throw on undefined/NaN/empty).
+ */
+export function isEmptyDateInput(dateInput: Date | string | null | undefined): boolean {
+  if (dateInput == null) {
+    return true
+  }
+  if (dateInput instanceof Date) {
+    return false
+  }
+  return String(dateInput).trim() === ''
+}
+
+/**
+ * Assert that a payroll date's year is within the allowed range.
+ *
+ * - Empty input (null/undefined/blank) is a no-op: required-field validation owns
+ *   that case (criteria E2 / B6). This function never throws on empty input.
+ * - Non-empty but unparseable input (e.g. "26-06-24") throws (criterion E3).
+ * - In-range parsed year is a no-op.
+ * - Out-of-range parsed year throws {@link PayrollDateRangeError}.
+ *
+ * @param dateInput a Date or date string (YYYY-MM-DD / MM-DD-YYYY / MM/DD/YYYY)
+ * @param fieldName the field being validated, surfaced in the error message/body
+ * @param now optional clock injection for deterministic tests
+ */
+export function assertPayrollDateInRange(
+  dateInput: Date | string | null | undefined,
+  fieldName: string,
+  now: Date = new Date()
+): void {
+  if (isEmptyDateInput(dateInput)) {
+    return
+  }
+
+  const year = extractYear(dateInput)
+  if (year === null || !isYearInRange(year, now)) {
+    throw new PayrollDateRangeError(fieldName, year, now)
+  }
+}


### PR DESCRIPTION
## Why

Production incident: an invoice **issue date** had its year mistyped `2026 → 2926` in an unvalidated `<input type="date">`. Nothing rejected it, and once saved it appeared as a selectable option in the issue-date dropdown — so three users re-selected it across a full pay run, corrupting `issue_date`/`pay_date` on ~333 invoices and the related `paystubs`, `overrides`, `expenses`, and `payroll` rows. (The spreadsheet importer was investigated and exonerated — sale dates were all correct.)

The bad data has been remediated separately. This PR prevents recurrence.

## What

- **Shared validator** (`src/lib/utils/dateValidation.ts`) — single source of truth. Allowed range is `2000 .. currentYear+1`, computed from the clock (auto-advances each year), used by client, server, and importer (no drift).
- **Server (authoritative)** — `POST /api/invoices` rejects out-of-range `issueDate` / `weekending` / `sale_date` with `400 { error, field, allowedRange }` **before any write**; repository-level backstop guard covers non-HTTP callers.
- **Client (`InvoiceEditor.tsx`)** — `min`/`max` on both date inputs; validation in the custom-date dialog and in `handleSave`; **filter out-of-range values from the issue-date dropdown** (this is the amplifier fix). Also fixes a latent dayjs format-token bug (`yyyy-MM-dd` → `YYYY-MM-DD`).
- **Excel importer** — enforces the same range in `validateAndFormatDate` so a mis-mapped numeric column can't silently become a far-future date.

## Tests

- 47 new unit tests across the validator, importer, and repository guard (negative/boundary/leap-year/empty cases). All green.
- Browser-validated end-to-end against local dev: client dialog rejection, `min`/`max` attributes, dropdown filtering, raw-HTTP server `400`, and the valid-2026 regression (HTTP 200 save).

---

## Also in this PR: impersonation "session already open" fix

**Why** — Admins were intermittently blocked from emulating users with a `409 "An impersonation session is already open"`, even when no banner/session was active.

**Root cause** — A timed-out impersonation session is auto-cleared from the JWT on refresh, but nothing wrote the expiry back to `user_impersonation_log`. The audit row leaked as "open" (`ended_at`/`end_reason` NULL), so `getActiveImpersonation` kept returning it and every future emulation attempt got a 409. The two sources of truth (JWT vs. DB) had diverged.

**What** — `POST /api/admin/impersonate/start` now checks the open row's TTL: an expired (or null-expiry) orphan is closed as `'expired'` and the new session proceeds; only a genuinely live session returns 409. This unblocks the flow and writes correct audit data. Self-heals existing orphans on next start.

**Tests** — 5 new route tests (no-open-row, live-409, expired-orphan self-heal, null-expiry orphan, non-SuperAdmin 403). All green.

**Note** — Already-leaked production rows can be cleared with a one-off `UPDATE user_impersonation_log SET ended_at = NOW(), end_reason = 'expired' WHERE ended_at IS NULL AND end_reason IS NULL AND (expires_at < NOW() OR expires_at IS NULL);` (or they self-heal as each affected admin starts a new session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
