### PR TITLE
Make careers pages dynamic to reflect real-time job posting changes

### DIFF
--- a/src/app/careers/[slug]/page.tsx
+++ b/src/app/careers/[slug]/page.tsx
@@ -13,6 +13,10 @@ import {
   formatWorkSetting,
 } from '@/components/careers/jobFormatters'
 
+// Render on every request so status/content changes to a posting are reflected
+// immediately instead of being served from the static route cache.
+export const dynamic = 'force-dynamic'
+
 interface Props {
   params: Promise<{ slug: string }>
 }

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -8,6 +8,11 @@ import JobListings from '@/components/careers/JobListings'
 import StatsBar from '@/components/careers/StatsBar'
 import CareersCTA from '@/components/careers/CareersCTA'
 
+// Render on every request so newly published/edited job postings appear
+// immediately. Without this the route is statically cached at build time and
+// the listing never reflects postings created after deploy.
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: 'Careers | Choice Marketing Partners',
   description:


### PR DESCRIPTION
## Summary
Updated the careers listing and individual job posting pages to render dynamically on every request instead of being statically cached at build time. This ensures newly published, edited, or removed job postings are reflected immediately without requiring a redeploy.

## Changes
- **`src/app/careers/page.tsx`**: Added `export const dynamic = 'force-dynamic'` to the careers listing page so job postings appear immediately after publication
- **`src/app/careers/[slug]/page.tsx`**: Added `export const dynamic = 'force-dynamic'` to individual job posting pages so status and content changes are reflected immediately

## Implementation Details
Both routes now use Next.js 15's dynamic rendering mode instead of static generation. This prevents the routes from being cached at build time, allowing the job listings to reflect real-time changes to the database without requiring a production redeploy. The change is minimal and leverages Next.js's built-in dynamic rendering capabilities.

https://claude.ai/code/session_01UjKrJVuWkKFboBySrFZfFn