### PR TITLE
fix: make admin employee search cover all employees

### DIFF
--- a/src/app/(portal)/admin/employees/page.tsx
+++ b/src/app/(portal)/admin/employees/page.tsx
@@ -36,10 +36,12 @@ export default async function EmployeesPage({ searchParams: paramsPromise }: Emp
     redirect('/forbidden')
   }
 
-  // Parse search parameters with active as default status
+  // Parse search parameters. An explicit status always wins; otherwise default
+  // to 'all' when searching (so search isn't silently scoped to active-only)
+  // and 'active' when just browsing.
   const filters = {
     search: searchParams.search,
-    status: (searchParams.status || 'active') as 'active' | 'inactive' | 'all',
+    status: (searchParams.status || (searchParams.search ? 'all' : 'active')) as 'active' | 'inactive' | 'all',
     role: (searchParams.role || 'all') as 'admin' | 'manager' | 'employee' | 'all',
     hasUser: searchParams.hasUser === 'true' ? true : 
              searchParams.hasUser === 'false' ? false : undefined,
@@ -53,8 +55,11 @@ export default async function EmployeesPage({ searchParams: paramsPromise }: Emp
     session.user.isManager || false
   )
 
-  // Fetch employees with server-side rendering
-  const employeePage = await employeeRepository.getEmployees(filters, userContext)
+  // Fetch employees and database-wide stats in parallel
+  const [employeePage, stats] = await Promise.all([
+    employeeRepository.getEmployees(filters, userContext),
+    employeeRepository.getEmployeeStats(userContext)
+  ])
 
   return (
     <div className="space-y-6">
@@ -77,24 +82,24 @@ export default async function EmployeesPage({ searchParams: paramsPromise }: Emp
       {/* Statistics */}
       <div className="grid gap-4 md:grid-cols-4">
         <div className="rounded-lg border p-4">
-          <div className="text-2xl font-bold">{employeePage.total}</div>
+          <div className="text-2xl font-bold">{stats.total}</div>
           <p className="text-sm text-muted-foreground">Total Employees</p>
         </div>
         <div className="rounded-lg border p-4">
           <div className="text-2xl font-bold text-primary">
-            {employeePage.employees.filter(emp => emp.is_active && !emp.deleted_at).length}
+            {stats.active}
           </div>
           <p className="text-sm text-muted-foreground">Active</p>
         </div>
         <div className="rounded-lg border p-4">
           <div className="text-2xl font-bold text-primary">
-            {employeePage.employees.filter(emp => emp.hasUser).length}
+            {stats.withUserAccounts}
           </div>
           <p className="text-sm text-muted-foreground">With User Accounts</p>
         </div>
         <div className="rounded-lg border p-4">
           <div className="text-2xl font-bold text-purple-600">
-            {employeePage.employees.filter(emp => emp.is_admin || emp.is_mgr).length}
+            {stats.managersAdmins}
           </div>
           <p className="text-sm text-muted-foreground">Managers/Admins</p>
         </div>

--- a/src/components/employees/EmployeeFilters.tsx
+++ b/src/components/employees/EmployeeFilters.tsx
@@ -27,9 +27,26 @@ export function EmployeeFilters({ initialFilters }: EmployeeFiltersProps) {
   const [status, setStatus] = useState(initialFilters.status)
   const [role, setRole] = useState(initialFilters.role)
   const [hasUser, setHasUser] = useState<string>(
-    initialFilters.hasUser === true ? 'true' : 
+    initialFilters.hasUser === true ? 'true' :
     initialFilters.hasUser === false ? 'false' : 'all'
   )
+  // Tracks whether the user has explicitly picked a status. Until they do,
+  // the status auto-widens/narrows as they type a search term so it's
+  // visually obvious that search now looks beyond "Active" employees.
+  // A status arriving via the URL only counts as explicit when it differs
+  // from what auto-widening would have produced for that URL's search term
+  // (updateFilters always writes status to the URL, explicit or not).
+  const [statusTouched, setStatusTouched] = useState(() => {
+    const urlStatus = searchParams.get('status')
+    return urlStatus !== null && urlStatus !== (initialFilters.search ? 'all' : 'active')
+  })
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value)
+    if (!statusTouched) {
+      setStatus(value.trim() ? 'all' : 'active')
+    }
+  }
 
   const updateFilters = () => {
     const params = new URLSearchParams(searchParams)
@@ -65,6 +82,7 @@ export function EmployeeFilters({ initialFilters }: EmployeeFiltersProps) {
   const clearFilters = () => {
     setSearch('')
     setStatus('active')  // Default to active instead of all
+    setStatusTouched(false)
     setRole('all')
     setHasUser('all')
     router.push('/admin/employees?status=active')  // Include active status in URL
@@ -82,9 +100,9 @@ export function EmployeeFilters({ initialFilters }: EmployeeFiltersProps) {
             <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
               id="search"
-              placeholder="Name, email, sales ID..."
+              placeholder="Name, email, phone, sales ID..."
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => handleSearchChange(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && updateFilters()}
               className="pl-8"
             />
@@ -94,7 +112,13 @@ export function EmployeeFilters({ initialFilters }: EmployeeFiltersProps) {
         {/* Status Filter */}
         <div className="space-y-2">
           <Label>Status</Label>
-          <Select value={status} onValueChange={(value) => setStatus(value as typeof status)}>
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              setStatusTouched(true)
+              setStatus(value as typeof status)
+            }}
+          >
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>

--- a/src/components/employees/EmployeeList.tsx
+++ b/src/components/employees/EmployeeList.tsx
@@ -233,7 +233,10 @@ export function EmployeeList({ initialData, currentFilters }: EmployeeListProps)
   const createPageUrl = (page: number) => {
     const params = new URLSearchParams()
     if (currentFilters.search) params.set('search', currentFilters.search)
-    if (currentFilters.status !== 'all') params.set('status', currentFilters.status)
+    // Always carry status: the server-side default depends on whether a
+    // search term is present ('all' with search, 'active' without), so an
+    // omitted status can silently narrow the results when paging.
+    params.set('status', currentFilters.status)
     if (currentFilters.role !== 'all') params.set('role', currentFilters.role)
     if (currentFilters.hasUser !== undefined) params.set('hasUser', currentFilters.hasUser.toString())
     params.set('page', page.toString())

--- a/src/lib/repositories/EmployeeRepository.ts
+++ b/src/lib/repositories/EmployeeRepository.ts
@@ -1,5 +1,7 @@
 import { db } from '@/lib/database/client'
 import bcrypt from 'bcryptjs'
+import type { ExpressionBuilder } from 'kysely'
+import type { DB } from '@/lib/database/types'
 import type { UserContext } from '@/lib/auth/types'
 
 /**
@@ -80,6 +82,13 @@ export interface EmployeePage {
   totalPages: number
 }
 
+export interface EmployeeStats {
+  total: number            // employees WHERE deleted_at IS NULL (all statuses)
+  active: number           // is_active > 0 AND deleted_at IS NULL
+  withUserAccounts: number // deleted_at IS NULL AND EXISTS employee_user link
+  managersAdmins: number   // is_active > 0 AND deleted_at IS NULL AND (is_admin = 1 OR is_mgr = 1)
+}
+
 /**
  * Repository for employee-related data operations
  */
@@ -101,9 +110,7 @@ export class EmployeeRepository {
 
     let query = db
       .selectFrom('employees')
-      .leftJoin('employee_user', 'employees.id', 'employee_user.employee_id')
-      .leftJoin('users', 'employee_user.user_id', 'users.uid')
-      .select([
+      .select((eb) => [
         'employees.id',
         'employees.name',
         'employees.email',
@@ -116,13 +123,19 @@ export class EmployeeRepository {
         'employees.phone_no',
         'employees.created_at',
         'employees.deleted_at',
-        db.case()
-          .when('users.uid', 'is not', null)
-          .then(true)
-          .else(false)
-          .end()
-          .as('hasUser'),
-        'users.id as user_id'
+        // Whether the employee has any linked user account (no row-multiplying join)
+        eb.exists(
+          eb.selectFrom('employee_user')
+            .select('employee_user.user_id')
+            .whereRef('employee_user.employee_id', '=', 'employees.id')
+        ).as('hasUser'),
+        // users.id (matches session.user.id used by the emulation button) via scalar subquery
+        eb.selectFrom('employee_user')
+          .innerJoin('users', 'users.uid', 'employee_user.user_id')
+          .select('users.id')
+          .whereRef('employee_user.employee_id', '=', 'employees.id')
+          .limit(1)
+          .as('user_id')
       ])
 
     // Apply filters
@@ -131,6 +144,7 @@ export class EmployeeRepository {
         eb.or([
           eb('employees.name', 'like', `%${search}%`),
           eb('employees.email', 'like', `%${search}%`),
+          eb('employees.phone_no', 'like', `%${search}%`),
           eb('employees.sales_id1', 'like', `%${search}%`),
           eb('employees.sales_id2', 'like', `%${search}%`),
           eb('employees.sales_id3', 'like', `%${search}%`)
@@ -160,10 +174,16 @@ export class EmployeeRepository {
     }
 
     if (hasUser !== undefined) {
+      const linkExists = (eb: ExpressionBuilder<DB, 'employees'>) =>
+        eb.exists(
+          eb.selectFrom('employee_user')
+            .select('employee_user.user_id')
+            .whereRef('employee_user.employee_id', '=', 'employees.id')
+        )
       if (hasUser) {
-        query = query.where('users.uid', 'is not', null)
+        query = query.where((eb) => linkExists(eb))
       } else {
-        query = query.where('users.uid', 'is', null)
+        query = query.where((eb) => eb.not(linkExists(eb)))
       }
     }
 
@@ -204,6 +224,91 @@ export class EmployeeRepository {
       page,
       limit,
       totalPages: Math.ceil(total / limit)
+    }
+  }
+
+  /**
+   * Get database-wide employee statistics, scoped by role.
+   *
+   * Uses a single query with conditional aggregation. Role scoping mirrors
+   * getEmployees: admins see global stats; managers see themselves plus their
+   * managed employees; plain employees see only themselves; a user with no
+   * employeeId and no admin rights gets all zeros.
+   */
+  async getEmployeeStats(userContext: UserContext): Promise<EmployeeStats> {
+    let query = db.selectFrom('employees')
+
+    // Role-based scoping
+    if (!userContext.isAdmin) {
+      if (userContext.isManager && userContext.managedEmployeeIds?.length) {
+        const accessibleIds = [userContext.employeeId!, ...userContext.managedEmployeeIds]
+        query = query.where('employees.id', 'in', accessibleIds)
+      } else if (userContext.employeeId) {
+        query = query.where('employees.id', '=', userContext.employeeId)
+      } else {
+        return { total: 0, active: 0, withUserAccounts: 0, managersAdmins: 0 }
+      }
+    }
+
+    const row = await query
+      .select((eb) => [
+        // total: not soft-deleted (all statuses)
+        eb.fn.sum(
+          eb.case()
+            .when('employees.deleted_at', 'is', null)
+            .then(1)
+            .else(0)
+            .end()
+        ).as('total'),
+        // active: is_active > 0 and not soft-deleted
+        eb.fn.sum(
+          eb.case()
+            .when(eb.and([
+              eb('employees.is_active', '>', 0),
+              eb('employees.deleted_at', 'is', null)
+            ]))
+            .then(1)
+            .else(0)
+            .end()
+        ).as('active'),
+        // withUserAccounts: not soft-deleted and has a linked user account
+        eb.fn.sum(
+          eb.case()
+            .when(eb.and([
+              eb('employees.deleted_at', 'is', null),
+              eb.exists(
+                eb.selectFrom('employee_user')
+                  .select('employee_user.user_id')
+                  .whereRef('employee_user.employee_id', '=', 'employees.id')
+              )
+            ]))
+            .then(1)
+            .else(0)
+            .end()
+        ).as('withUserAccounts'),
+        // managersAdmins: active, not deleted, and admin or manager
+        eb.fn.sum(
+          eb.case()
+            .when(eb.and([
+              eb('employees.is_active', '>', 0),
+              eb('employees.deleted_at', 'is', null),
+              eb.or([
+                eb('employees.is_admin', '=', 1),
+                eb('employees.is_mgr', '=', 1)
+              ])
+            ]))
+            .then(1)
+            .else(0)
+            .end()
+        ).as('managersAdmins')
+      ])
+      .executeTakeFirst()
+
+    return {
+      total: Number(row?.total ?? 0),
+      active: Number(row?.active ?? 0),
+      withUserAccounts: Number(row?.withUserAccounts ?? 0),
+      managersAdmins: Number(row?.managersAdmins ?? 0)
     }
   }
 

--- a/src/lib/repositories/__tests__/EmployeeRepository.search-stats.test.ts
+++ b/src/lib/repositories/__tests__/EmployeeRepository.search-stats.test.ts
@@ -1,0 +1,235 @@
+import { EmployeeRepository } from '../EmployeeRepository'
+import { db } from '@/lib/database/client'
+import type { UserContext } from '@/lib/auth/types'
+
+jest.mock('@/lib/database/client', () => ({
+  db: {
+    selectFrom: jest.fn(),
+    fn: {
+      count: jest.fn().mockReturnValue({
+        as: jest.fn().mockReturnValue('count_expr'),
+      }),
+    },
+  },
+}))
+
+const adminCtx: UserContext = { employeeId: 1, isAdmin: true, isManager: false }
+const managerCtx: UserContext = { employeeId: 2, isAdmin: false, isManager: true, managedEmployeeIds: [10, 11, 12] }
+const employeeCtx: UserContext = { employeeId: 3, isAdmin: false, isManager: false }
+const nobodyCtx: UserContext = { isAdmin: false, isManager: false }
+
+/**
+ * A recording expression-builder stand-in. The real Kysely `eb` produces SQL
+ * fragments; here we just capture which columns/operators were referenced and
+ * whether exists()/not()/or() were used, so we can assert on the *shape* of the
+ * predicates the repository builds. SQL semantics (join fan-out, EXISTS results,
+ * distinct counts) are verified separately against a live MySQL via the probe
+ * script in .pi/probe/employees.ts — pure mocks cannot express those.
+ */
+function makeRecordingEb() {
+  const calls: Array<{ type: string; args?: unknown[]; col?: unknown }> = []
+  const subquery: Record<string, unknown> = {}
+  subquery.select = jest.fn(() => subquery)
+  subquery.innerJoin = jest.fn(() => subquery)
+  subquery.whereRef = jest.fn(() => subquery)
+  subquery.limit = jest.fn(() => subquery)
+  subquery.as = jest.fn(() => ({}))
+
+  const eb = ((...args: unknown[]) => {
+    calls.push({ type: 'cmp', args, col: args[0] })
+    return { __cmp: args }
+  }) as unknown as {
+    (...args: unknown[]): unknown
+    or: (a: unknown[]) => unknown
+    and: (a: unknown[]) => unknown
+    not: (x: unknown) => unknown
+    exists: (x: unknown) => unknown
+    selectFrom: () => Record<string, unknown>
+    calls: typeof calls
+  }
+  eb.or = (arr: unknown[]) => ({ __or: arr })
+  eb.and = (arr: unknown[]) => ({ __and: arr })
+  eb.not = (x: unknown) => {
+    calls.push({ type: 'not', args: [x] })
+    return { __not: x }
+  }
+  eb.exists = (x: unknown) => {
+    calls.push({ type: 'exists', args: [x] })
+    return { __exists: x }
+  }
+  eb.selectFrom = () => subquery
+  eb.calls = calls
+  return eb
+}
+
+function setupGetEmployeesMock() {
+  const mockQuery = {
+    leftJoin: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    clearSelect: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue([]),
+    executeTakeFirst: jest.fn().mockResolvedValue({ count: 0 }),
+  }
+  ;(db.selectFrom as jest.Mock).mockReturnValue(mockQuery)
+  return mockQuery
+}
+
+/** Invoke every function-valued `where(...)` argument with a fresh recording eb
+ * and aggregate what each predicate referenced. */
+function collectWhereEbRecords(mockQuery: { where: jest.Mock }) {
+  const records: Array<{ type: string; args?: unknown[]; col?: unknown }> = []
+  for (const call of mockQuery.where.mock.calls) {
+    if (typeof call[0] === 'function') {
+      const eb = makeRecordingEb()
+      call[0](eb)
+      records.push(...eb.calls)
+    }
+  }
+  return records
+}
+
+describe('EmployeeRepository.getEmployees — search & join changes', () => {
+  let repo: EmployeeRepository
+
+  beforeEach(() => {
+    repo = new EmployeeRepository()
+    jest.clearAllMocks()
+  })
+
+  it('no longer left-joins employee_user/users (row-multiplying joins removed)', async () => {
+    const mockQuery = setupGetEmployeesMock()
+    await repo.getEmployees({}, adminCtx)
+    expect(mockQuery.leftJoin).not.toHaveBeenCalled()
+  })
+
+  it('search matches employees.phone_no in addition to name/email/sales ids', async () => {
+    const mockQuery = setupGetEmployeesMock()
+    await repo.getEmployees({ search: '4199619029' }, adminCtx)
+
+    const cols = collectWhereEbRecords(mockQuery)
+      .filter((r) => r.type === 'cmp')
+      .map((r) => r.col)
+
+    expect(cols).toContain('employees.phone_no')
+    expect(cols).toContain('employees.name')
+    expect(cols).toContain('employees.email')
+    expect(cols).toContain('employees.sales_id1')
+    expect(cols).toContain('employees.sales_id2')
+    expect(cols).toContain('employees.sales_id3')
+  })
+
+  it('hasUser: true filters with an EXISTS subquery (no NOT)', async () => {
+    const mockQuery = setupGetEmployeesMock()
+    await repo.getEmployees({ hasUser: true }, adminCtx)
+
+    const records = collectWhereEbRecords(mockQuery)
+    expect(records.some((r) => r.type === 'exists')).toBe(true)
+    expect(records.some((r) => r.type === 'not')).toBe(false)
+  })
+
+  it('hasUser: false filters with a NOT EXISTS subquery', async () => {
+    const mockQuery = setupGetEmployeesMock()
+    await repo.getEmployees({ hasUser: false }, adminCtx)
+
+    const records = collectWhereEbRecords(mockQuery)
+    expect(records.some((r) => r.type === 'exists')).toBe(true)
+    expect(records.some((r) => r.type === 'not')).toBe(true)
+  })
+
+  it('maps hasUser/user_id onto the returned EmployeeSummary shape', async () => {
+    const mockQuery = setupGetEmployeesMock()
+    mockQuery.execute.mockResolvedValueOnce([
+      {
+        id: 70, name: '41 Energy', email: 'e@e.com', is_active: 1, is_admin: 0,
+        is_mgr: 0, sales_id1: '', sales_id2: '', sales_id3: '', phone_no: '22343232',
+        created_at: new Date(), deleted_at: null, hasUser: 1, user_id: 70,
+      },
+      {
+        id: 1014, name: 'Aaron Bond', email: 'a@a.com', is_active: 1, is_admin: 0,
+        is_mgr: 0, sales_id1: '', sales_id2: '', sales_id3: '', phone_no: '4199619029',
+        created_at: new Date(), deleted_at: null, hasUser: 0, user_id: null,
+      },
+    ])
+    mockQuery.executeTakeFirst.mockResolvedValueOnce({ count: 2 })
+
+    const result = await repo.getEmployees({}, adminCtx)
+
+    expect(result.total).toBe(2)
+    expect(result.employees[0]).toMatchObject({ id: 70, hasUser: true, user_id: 70 })
+    expect(result.employees[1]).toMatchObject({ id: 1014, hasUser: false, user_id: null })
+  })
+})
+
+describe('EmployeeRepository.getEmployeeStats', () => {
+  let repo: EmployeeRepository
+
+  function setupStatsMock(row: Record<string, unknown> | undefined) {
+    const mockQuery = {
+      where: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      executeTakeFirst: jest.fn().mockResolvedValue(row),
+    }
+    ;(db.selectFrom as jest.Mock).mockReturnValue(mockQuery)
+    return mockQuery
+  }
+
+  beforeEach(() => {
+    repo = new EmployeeRepository()
+    jest.clearAllMocks()
+  })
+
+  it('returns the four coerced numeric stats from the aggregate row', async () => {
+    // MySQL SUM(...) commonly returns strings — assert they are coerced to numbers.
+    setupStatsMock({ total: '543', active: '541', withUserAccounts: '27', managersAdmins: '9' })
+
+    const stats = await repo.getEmployeeStats(adminCtx)
+
+    expect(stats).toEqual({ total: 543, active: 541, withUserAccounts: 27, managersAdmins: 9 })
+  })
+
+  it('coerces a null/empty aggregate (no matching rows) to zeros', async () => {
+    setupStatsMock({ total: null, active: null, withUserAccounts: null, managersAdmins: null })
+
+    const stats = await repo.getEmployeeStats(adminCtx)
+
+    expect(stats).toEqual({ total: 0, active: 0, withUserAccounts: 0, managersAdmins: 0 })
+  })
+
+  it('admin: does not scope by employee id (global stats)', async () => {
+    const mockQuery = setupStatsMock({ total: 1, active: 1, withUserAccounts: 1, managersAdmins: 1 })
+
+    await repo.getEmployeeStats(adminCtx)
+
+    expect(mockQuery.where).not.toHaveBeenCalled()
+    expect(mockQuery.executeTakeFirst).toHaveBeenCalledTimes(1)
+  })
+
+  it('manager: scopes to self plus managed employee ids', async () => {
+    const mockQuery = setupStatsMock({ total: 4, active: 4, withUserAccounts: 2, managersAdmins: 1 })
+
+    await repo.getEmployeeStats(managerCtx)
+
+    expect(mockQuery.where).toHaveBeenCalledWith('employees.id', 'in', [2, 10, 11, 12])
+  })
+
+  it('plain employee: scopes to only their own id', async () => {
+    const mockQuery = setupStatsMock({ total: 1, active: 1, withUserAccounts: 0, managersAdmins: 0 })
+
+    await repo.getEmployeeStats(employeeCtx)
+
+    expect(mockQuery.where).toHaveBeenCalledWith('employees.id', '=', 3)
+  })
+
+  it('no employeeId and not admin: returns all zeros without querying', async () => {
+    const mockQuery = setupStatsMock({ total: 999, active: 999, withUserAccounts: 999, managersAdmins: 999 })
+
+    const stats = await repo.getEmployeeStats(nobodyCtx)
+
+    expect(stats).toEqual({ total: 0, active: 0, withUserAccounts: 0, managersAdmins: 0 })
+    expect(mockQuery.executeTakeFirst).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

Searching on `/admin/employees` appeared to only find employees who have user accounts with a sales ID. Investigation showed the search query itself was fine — the real causes:

1. **The default `Status: Active` filter silently applied to searches.** 665 of 1,208 employees are soft-deleted and invisible to search with no hint that matches exist, so searches for them returned "No employees found".
2. **Stat cards were computed from the current page of 20 cards**, not the database (e.g. "3 With User Accounts" when there are 100+), reinforcing the impression that most employees weren't tracked.
3. Latent bug: employees with multiple linked user accounts were duplicated in results and double-counted in pagination totals.

## Changes

- **Search auto-widens status to All** — typing a search term visibly flips the Status dropdown to "All Status" so every employee (active, inactive, deleted; with or without a user account) is findable. An explicitly chosen status always wins and is never clobbered.
- Server-side default status is search-aware: `all` when `?search=` is present, `active` when browsing.
- **Stat cards now show true DB-wide aggregates** via new `EmployeeRepository.getEmployeeStats()` (RBAC-scoped like `getEmployees`).
- `getEmployees` replaced row-multiplying `LEFT JOIN`s with `EXISTS`/scalar subqueries — no more duplicate cards or inflated counts.
- Phone number added to searchable fields (placeholder updated).

## Verification

- Unit tests: 32 pass (new suite covers phone search, hasUser EXISTS filtering, stats definitions + RBAC scoping). The new tests fail against the old repository code, confirming they guard the fix.
- `tsc --noEmit`, lint, and production build clean for touched files.
- Playwright browser smoke against a local copy of prod data: soft-deleted no-account employee findable via typed search and via URL; explicit `status=active` respected and not clobbered while typing; stat cards show 543/541/27/9 DB-wide; active no-account employees findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)