### PR TITLE
fix: email uniqueness false positives, employee→user email sync, and login email parking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,16 @@ Route protection handled by `middleware.ts`:
 **CRITICAL**: Preserve existing MySQL schema from Laravel migration - do NOT make structural database changes.
 
 Key patterns:
-- **Employee-User linking**: Via `employee_user` junction table
+- **Employee-User linking (DUAL — both conventions are live in prod data)**:
+  1. the `employee_user` junction table (~105 rows), and
+  2. the legacy Laravel convention `users.id = employees.id` (~1149 rows) — this is
+     how NextAuth resolves the employee at sign-in (`src/lib/auth/config.ts`).
+
+  Over 500 active employees have **only** the legacy link, so any query that consults
+  just the junction table misses ~93% of logins. Resolve the relation as the **union**
+  of both (`EmployeeRepository.isLinkedLoginAccount`), never one alone. Note `users.id`
+  is a plain non-unique int (`uid` is the PK), so an employee can resolve to several
+  user rows — handle a set, and guard `users.id > 0`.
 - **Role flags**: `is_admin`, `is_mgr` on `employees` table
 - **Soft deletes**: `deleted_at` timestamps, `is_active` flags
 - **Sales tracking**: `sales_id1`, `sales_id2`, `sales_id3` for payroll calculations

--- a/src/app/api/employees/[id]/__tests__/route.test.ts
+++ b/src/app/api/employees/[id]/__tests__/route.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any -- route test doubles are intentionally untyped */
+
+// ── Mocks (hoisted by jest) ────────────────────────────────────────────────────
+/* eslint-disable no-var */
+var repoMock: any
+/* eslint-enable no-var */
+
+jest.mock('@/lib/repositories/EmployeeRepository', () => {
+  repoMock = {
+    getEmployeeById: jest.fn(),
+    findEmailOwner: jest.fn().mockResolvedValue(null),
+    updateEmployee: jest.fn(),
+    softDeleteEmployee: jest.fn().mockResolvedValue(true),
+  }
+
+  return {
+    EmployeeRepository: jest.fn(() => repoMock),
+    isDuplicateEmailError: (error: any) =>
+      error?.code === 'ER_DUP_ENTRY' || error?.errno === 1062,
+  }
+})
+
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }))
+jest.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+jest.mock('@/lib/auth/payroll-access', () => ({
+  getEmployeeContext: jest.fn().mockResolvedValue({ employeeId: 1, isAdmin: true, isManager: false }),
+}))
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { error: jest.fn(), log: jest.fn(), warn: jest.fn() },
+}))
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────────
+import { PUT, DELETE } from '../route'
+import { getServerSession } from 'next-auth'
+import { ParkedEmailTooLongError } from '@/lib/utils/email'
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+const liveEmployee = {
+  id: 1252, name: 'Chaise Scott', email: 'Chaise.Scott@Gmail.com', deleted_at: null,
+}
+const deletedEmployee = { ...liveEmployee, deleted_at: new Date('2020-03-15') }
+
+function makeRequest(body: object) {
+  return new Request('http://localhost:3000/api/employees/1252', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as any
+}
+
+function makeParams(id = '1252') {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('PUT /api/employees/[id] — email guards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getServerSession as jest.Mock).mockResolvedValue({ user: { isAdmin: true } })
+    repoMock.findEmailOwner.mockResolvedValue(null)
+    repoMock.updateEmployee.mockResolvedValue({ ...liveEmployee })
+  })
+
+  it('refuses to change the email of a soft-deleted employee', async () => {
+    repoMock.getEmployeeById.mockResolvedValue(deletedEmployee)
+
+    const response = await PUT(makeRequest({ email: 'new@gmail.com' }), makeParams())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Restore this employee before changing their email address.',
+    })
+    expect(repoMock.updateEmployee).not.toHaveBeenCalled()
+  })
+
+  it('still allows other field edits on a soft-deleted employee', async () => {
+    repoMock.getEmployeeById.mockResolvedValue(deletedEmployee)
+
+    const response = await PUT(makeRequest({ city: 'Toledo' }), makeParams())
+
+    expect(response.status).toBe(200)
+    expect(repoMock.updateEmployee).toHaveBeenCalled()
+  })
+
+  it('treats a case-only difference as unchanged (MySQL compares case-insensitively)', async () => {
+    repoMock.getEmployeeById.mockResolvedValue(deletedEmployee)
+
+    const response = await PUT(makeRequest({ email: 'chaise.scott@gmail.com' }), makeParams())
+
+    // Not a real change, so the deleted-employee guard must not fire.
+    expect(response.status).toBe(200)
+    expect(repoMock.findEmailOwner).not.toHaveBeenCalled()
+  })
+
+  it('returns the owner-aware conflict message for a live employee', async () => {
+    repoMock.getEmployeeById.mockResolvedValue(liveEmployee)
+    repoMock.findEmailOwner.mockResolvedValue({
+      source: 'user', employeeId: 1256, employeeName: 'Someone Else', employeeDeleted: true,
+    })
+
+    const response = await PUT(makeRequest({ email: 'taken@gmail.com' }), makeParams())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Email address is already in use by the login account of deleted employee Someone Else (#1256).',
+    })
+  })
+
+  it('maps a lost unique-index race to the same 400 conflict', async () => {
+    repoMock.getEmployeeById.mockResolvedValue(liveEmployee)
+    repoMock.updateEmployee.mockRejectedValue(
+      Object.assign(new Error('Duplicate entry'), { code: 'ER_DUP_ENTRY', errno: 1062 })
+    )
+
+    const response = await PUT(makeRequest({ email: 'racy@gmail.com' }), makeParams())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Email address is already in use.',
+    })
+  })
+
+  it('trims the submitted address before comparing', async () => {
+    repoMock.getEmployeeById.mockResolvedValue(liveEmployee)
+
+    const response = await PUT(makeRequest({ email: '  chaise.scott@gmail.com  ' }), makeParams())
+
+    expect(response.status).toBe(200)
+    expect(repoMock.findEmailOwner).not.toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/employees/[id] — unparkable login email', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getServerSession as jest.Mock).mockResolvedValue({ user: { isAdmin: true } })
+    repoMock.getEmployeeById.mockResolvedValue(liveEmployee)
+  })
+
+  it('returns 400 with the descriptive message instead of an opaque 500', async () => {
+    repoMock.softDeleteEmployee.mockRejectedValue(
+      new ParkedEmailTooLongError('Login email too long to park for employee 1252: ...')
+    )
+
+    const request = new Request('http://localhost:3000/api/employees/1252', { method: 'DELETE' }) as any
+    const response = await DELETE(request, makeParams())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Login email too long to park for employee 1252: ...',
+    })
+  })
+
+  it('still returns 500 for unrelated failures', async () => {
+    repoMock.softDeleteEmployee.mockRejectedValue(new Error('connection lost'))
+
+    const request = new Request('http://localhost:3000/api/employees/1252', { method: 'DELETE' }) as any
+    const response = await DELETE(request, makeParams())
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to delete employee' })
+  })
+})

--- a/src/app/api/employees/[id]/restore/route.ts
+++ b/src/app/api/employees/[id]/restore/route.ts
@@ -33,9 +33,9 @@ export async function PUT(
       session.user.isManager
     )
 
-    const success = await employeeRepository.restoreEmployee(employeeId, userContext)
+    const result = await employeeRepository.restoreEmployee(employeeId, userContext)
 
-    if (!success) {
+    if (!result.restored) {
       return NextResponse.json(
         { error: 'Failed to restore employee or employee not found' },
         { status: 500 }
@@ -46,7 +46,14 @@ export async function PUT(
 
     return NextResponse.json({
       message: 'Employee restored successfully',
-      employee: restoredEmployee
+      employee: restoredEmployee,
+      // Optional: the login email stayed parked because the address is now taken.
+      ...(result.emailsStillParked > 0
+        ? {
+            warning:
+              'The login email for this employee could not be released because the address is now in use. Update the employee email manually to restore login access.'
+          }
+        : {})
     })
   } catch (error) {
     logger.error('Error restoring employee:', error)

--- a/src/app/api/employees/[id]/route.ts
+++ b/src/app/api/employees/[id]/route.ts
@@ -1,16 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
-import { EmployeeRepository } from '@/lib/repositories/EmployeeRepository'
+import { EmployeeRepository, isDuplicateEmailError } from '@/lib/repositories/EmployeeRepository'
 import { z } from 'zod'
 import { logger } from '@/lib/utils/logger'
 import { getEmployeeContext } from '@/lib/auth/payroll-access'
+import { emailConflictMessage, isParkTooLongError, normalizeEmail } from '@/lib/utils/email'
 
 const employeeRepository = new EmployeeRepository()
 
 const updateEmployeeSchema = z.object({
   name: z.string().min(1, 'Name is required').optional(),
-  email: z.string().email('Valid email is required').optional(),
+  email: z.string().trim().email('Valid email is required').optional(),
   phone_no: z.string().optional(),
   address: z.string().min(1, 'Address is required').optional(),
   address_2: z.string().optional(),
@@ -104,26 +105,50 @@ export async function PUT(
       return NextResponse.json({ error: 'Employee not found' }, { status: 404 })
     }
 
-    // Check email availability if email is being changed
-    if (data.email && data.email !== existingEmployee.email) {
-      const emailAvailable = await employeeRepository.isEmailAvailable(data.email, employeeId)
-      if (!emailAvailable) {
+    // Check email availability if email is being changed.
+    // MySQL compares these columns case-insensitively, so compare normalized values.
+    const normalizedEmail = data.email !== undefined ? normalizeEmail(data.email) : undefined
+    if (normalizedEmail && normalizedEmail !== normalizeEmail(existingEmployee.email)) {
+      // A deleted employee's login email is parked, so the two records cannot be
+      // kept in sync. Say so plainly instead of silently drifting them apart.
+      if (existingEmployee.deleted_at) {
         return NextResponse.json(
-          { error: 'Email address is already in use' },
+          { error: 'Restore this employee before changing their email address.' },
+          { status: 400 }
+        )
+      }
+
+      const owner = await employeeRepository.findEmailOwner(normalizedEmail, employeeId)
+      if (owner) {
+        return NextResponse.json(
+          { error: emailConflictMessage(owner) },
           { status: 400 }
         )
       }
     }
 
-    const updatedEmployee = await employeeRepository.updateEmployee(employeeId, data, userContext)
+    const updatedEmployee = await employeeRepository.updateEmployee(
+      employeeId,
+      normalizedEmail !== undefined ? { ...data, email: normalizedEmail } : data,
+      userContext
+    )
 
     return NextResponse.json({ employee: updatedEmployee })
   } catch (error) {
     logger.error('Error updating employee:', error)
-    
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Validation failed', details: error.issues },
+        { status: 400 }
+      )
+    }
+
+    // Lost the race against another writer: the users_email_unique index rolled
+    // the whole update back — report the same conflict the pre-check reports.
+    if (isDuplicateEmailError(error)) {
+      return NextResponse.json(
+        { error: 'Email address is already in use.' },
         { status: 400 }
       )
     }
@@ -179,6 +204,13 @@ export async function DELETE(
     return NextResponse.json({ message: 'Employee deleted successfully' })
   } catch (error) {
     logger.error('Error deleting employee:', error)
+
+    // The login email cannot be parked without overflowing the column — an
+    // admin-fixable situation, not a server fault.
+    if (isParkTooLongError(error)) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+
     return NextResponse.json(
       { error: 'Failed to delete employee' },
       { status: 500 }

--- a/src/app/api/employees/email-available/route.ts
+++ b/src/app/api/employees/email-available/route.ts
@@ -4,11 +4,12 @@ import { authOptions } from '@/lib/auth/config'
 import { EmployeeRepository } from '@/lib/repositories/EmployeeRepository'
 import { z } from 'zod'
 import { logger } from '@/lib/utils/logger'
+import { emailConflictMessage, normalizeEmail } from '@/lib/utils/email'
 
 const employeeRepository = new EmployeeRepository()
 
 const emailCheckSchema = z.object({
-  email: z.string().email('Valid email is required'),
+  email: z.string().trim().email('Valid email is required'),
   excludeEmployeeId: z.number().optional()
 })
 
@@ -26,12 +27,17 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const data = emailCheckSchema.parse(body)
 
-    const available = await employeeRepository.isEmailAvailable(
-      data.email,
+    const owner = await employeeRepository.findEmailOwner(
+      normalizeEmail(data.email),
       data.excludeEmployeeId
     )
 
-    return NextResponse.json({ available })
+    // `message` is the same actionable text the create/update routes return, so
+    // the inline check and the submit-time error always agree.
+    return NextResponse.json({
+      available: owner === null,
+      message: owner ? emailConflictMessage(owner) : null
+    })
   } catch (error) {
     logger.error('Error checking email availability:', error)
     

--- a/src/app/api/employees/route.ts
+++ b/src/app/api/employees/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
-import { EmployeeRepository } from '@/lib/repositories/EmployeeRepository'
+import { EmployeeRepository, isDuplicateEmailError } from '@/lib/repositories/EmployeeRepository'
+import { emailConflictMessage, normalizeEmail } from '@/lib/utils/email'
 import { generatePassword } from '@/lib/utils/password'
 import { sendWelcomeEmail } from '@/lib/services/email'
 import { z } from 'zod'
@@ -22,7 +23,7 @@ const employeeFiltersSchema = z.object({
 
 const createEmployeeSchema = z.object({
   name: z.string().min(1, 'Name is required'),
-  email: z.string().email('Valid email is required'),
+  email: z.string().trim().email('Valid email is required'),
   phone_no: z.string().optional(),
   address: z.string().min(1, 'Address is required'),
   address_2: z.string().optional(),
@@ -96,11 +97,12 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const data = createEmployeeSchema.parse(body)
 
-    // Check email availability
-    const emailAvailable = await employeeRepository.isEmailAvailable(data.email)
-    if (!emailAvailable) {
+    // Check email availability (normalized: MySQL compares case-insensitively)
+    const email = normalizeEmail(data.email)
+    const emailOwner = await employeeRepository.findEmailOwner(email)
+    if (emailOwner) {
       return NextResponse.json(
-        { error: 'Email address is already in use' },
+        { error: emailConflictMessage(emailOwner) },
         { status: 400 }
       )
     }
@@ -130,7 +132,7 @@ export async function POST(request: NextRequest) {
     const employee = await employeeRepository.createEmployeeWithUser(
       {
         name: data.name,
-        email: data.email,
+        email,
         phone_no: data.phone_no,
         address: data.address,
         address_2: data.address_2,
@@ -157,7 +159,7 @@ export async function POST(request: NextRequest) {
     if (data.createUser && userPassword) {
       try {
         await sendWelcomeEmail({
-          to: data.email,
+          to: email,
           name: data.name,
           password: userPassword
         })
@@ -174,10 +176,18 @@ export async function POST(request: NextRequest) {
     }, { status: 201 })
   } catch (error) {
     logger.error('Error creating employee:', error)
-    
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Validation failed', details: error.issues },
+        { status: 400 }
+      )
+    }
+
+    // Lost the race against another writer on users_email_unique.
+    if (isDuplicateEmailError(error)) {
+      return NextResponse.json(
+        { error: 'Email address is already in use.' },
         { status: 400 }
       )
     }

--- a/src/components/employees/EmployeeForm.tsx
+++ b/src/components/employees/EmployeeForm.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState, FormEvent } from 'react'
+import { useState, useRef, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 import { EmployeeDetail, CreateEmployeeData } from '@/lib/repositories/EmployeeRepository'
+import { normalizeEmail } from '@/lib/utils/email'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -23,6 +24,10 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [generatedPassword, setGeneratedPassword] = useState<string | null>(null)
+  const [emailConflict, setEmailConflict] = useState<string | null>(null)
+  const [checkingEmail, setCheckingEmail] = useState(false)
+  // Guards against a slow earlier check overwriting a newer result.
+  const emailCheckSeq = useRef(0)
 
   // Form state
   const [formData, setFormData] = useState({
@@ -49,6 +54,54 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
 
   const handleInputChange = (field: string, value: string | boolean) => {
     setFormData(prev => ({ ...prev, [field]: value }))
+    if (field === 'email') setEmailConflict(null)
+  }
+
+  /**
+   * Lightweight pre-submit check so the admin learns *who* holds the address
+   * before saving. The server-side check remains authoritative.
+   */
+  const checkEmailAvailability = async () => {
+    const email = normalizeEmail(formData.email)
+
+    // Bump the sequence on every path — including the early returns — so a
+    // slow in-flight check can never paint a conflict on a newer value. That
+    // also orphans its finally-block, so the early returns must clear the
+    // spinner themselves or "Checking availability..." sticks forever.
+    const seq = ++emailCheckSeq.current
+    setEmailConflict(null)
+
+    // Only ask the server about a plausible, actually-changed address.
+    const isCheckable = Boolean(email) && email.includes('@')
+    const isUnchanged = Boolean(employee) && normalizeEmail(employee!.email) === email
+    if (!isCheckable || isUnchanged) {
+      setCheckingEmail(false)
+      return
+    }
+
+    setCheckingEmail(true)
+
+    try {
+      const response = await fetch('/api/employees/email-available', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, excludeEmployeeId: employee?.id })
+      })
+
+      if (!response.ok) return
+
+      const result = await response.json()
+      if (seq !== emailCheckSeq.current) return
+      if (!result.available) {
+        setEmailConflict(result.message || 'Email address is already in use.')
+      }
+    } catch (error) {
+      // Non-blocking: the submit-time check still guards the write.
+      logger.error('Error checking email availability:', error)
+    } finally {
+      if (seq === emailCheckSeq.current) setCheckingEmail(false)
+    }
   }
 
   const onSubmit = async (e: FormEvent) => {
@@ -59,7 +112,8 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
     try {
       const employeeData: CreateEmployeeData = {
         name: formData.name,
-        email: formData.email,
+        // Trim to match the inline availability check (and the API schemas).
+        email: formData.email.trim(),
         phone_no: formData.phone_no,
         address: formData.address,
         address_2: formData.address_2,
@@ -205,9 +259,20 @@ export function EmployeeForm({ employee, mode = 'create' }: EmployeeFormProps) {
                   type="email"
                   value={formData.email}
                   onChange={(e) => handleInputChange('email', e.target.value)}
+                  onBlur={checkEmailAvailability}
                   placeholder="john@example.com"
+                  aria-invalid={emailConflict ? true : undefined}
+                  aria-describedby={emailConflict ? 'email-conflict' : undefined}
                   required
                 />
+                {checkingEmail && (
+                  <p className="text-sm text-muted-foreground">Checking availability...</p>
+                )}
+                {emailConflict && (
+                  <p id="email-conflict" className="text-sm text-destructive">
+                    {emailConflict}
+                  </p>
+                )}
               </div>
 
               <div className="space-y-2">

--- a/src/components/employees/EmployeeList.tsx
+++ b/src/components/employees/EmployeeList.tsx
@@ -194,6 +194,11 @@ export function EmployeeList({ initialData, currentFilters }: EmployeeListProps)
       })
 
       if (response.ok) {
+        // The login email can stay parked when the address was reused meanwhile.
+        const data = await response.json().catch(() => ({}))
+        if (data.warning) {
+          toast({ title: 'Employee restored', description: data.warning })
+        }
         // Refresh the page to get updated data from server
         router.refresh()
       } else {

--- a/src/lib/repositories/EmployeeRepository.ts
+++ b/src/lib/repositories/EmployeeRepository.ts
@@ -1,8 +1,18 @@
 import { db } from '@/lib/database/client'
 import bcrypt from 'bcryptjs'
-import type { ExpressionBuilder } from 'kysely'
+import type { Expression, ExpressionBuilder, Kysely } from 'kysely'
 import type { DB } from '@/lib/database/types'
 import type { UserContext } from '@/lib/auth/types'
+import {
+  buildParkedEmail,
+  isParkedEmail,
+  normalizeEmail,
+  unparkEmail,
+  type EmailOwnerInfo
+} from '@/lib/utils/email'
+
+/** Either the shared connection or an open transaction. */
+type DbExecutor = Kysely<DB>
 
 /**
  * Employee management interfaces
@@ -82,10 +92,17 @@ export interface EmployeePage {
   totalPages: number
 }
 
+export interface RestoreEmployeeResult {
+  /** True when the employees row was un-deleted. */
+  restored: boolean
+  /** Login emails that could not be un-parked because the address is taken. */
+  emailsStillParked: number
+}
+
 export interface EmployeeStats {
   total: number            // employees WHERE deleted_at IS NULL (all statuses)
   active: number           // is_active > 0 AND deleted_at IS NULL
-  withUserAccounts: number // deleted_at IS NULL AND EXISTS employee_user link
+  withUserAccounts: number // deleted_at IS NULL AND has a login by either linkage convention
   managersAdmins: number   // is_active > 0 AND deleted_at IS NULL AND (is_admin = 1 OR is_mgr = 1)
 }
 
@@ -123,17 +140,14 @@ export class EmployeeRepository {
         'employees.phone_no',
         'employees.created_at',
         'employees.deleted_at',
-        // Whether the employee has any linked user account (no row-multiplying join)
-        eb.exists(
-          eb.selectFrom('employee_user')
-            .select('employee_user.user_id')
-            .whereRef('employee_user.employee_id', '=', 'employees.id')
-        ).as('hasUser'),
+        // Whether the employee has any linked user account, by either linkage
+        // convention (no row-multiplying join)
+        this.hasLinkedLoginAccountSet(eb).as('hasUser'),
         // users.id (matches session.user.id used by the emulation button) via scalar subquery
-        eb.selectFrom('employee_user')
-          .innerJoin('users', 'users.uid', 'employee_user.user_id')
+        eb.selectFrom('users')
           .select('users.id')
-          .whereRef('employee_user.employee_id', '=', 'employees.id')
+          .where((inner) => this.isLinkedLoginAccount(inner, eb.ref('employees.id')))
+          .orderBy('users.uid', 'asc')
           .limit(1)
           .as('user_id')
       ])
@@ -174,16 +188,10 @@ export class EmployeeRepository {
     }
 
     if (hasUser !== undefined) {
-      const linkExists = (eb: ExpressionBuilder<DB, 'employees'>) =>
-        eb.exists(
-          eb.selectFrom('employee_user')
-            .select('employee_user.user_id')
-            .whereRef('employee_user.employee_id', '=', 'employees.id')
-        )
       if (hasUser) {
-        query = query.where((eb) => linkExists(eb))
+        query = query.where((eb) => this.hasLinkedLoginAccountSet(eb))
       } else {
-        query = query.where((eb) => eb.not(linkExists(eb)))
+        query = query.where((eb) => eb.not(this.hasLinkedLoginAccountSet(eb)))
       }
     }
 
@@ -272,15 +280,12 @@ export class EmployeeRepository {
             .end()
         ).as('active'),
         // withUserAccounts: not soft-deleted and has a linked user account
+        // (either linkage convention — must agree with the list's hasUser flag)
         eb.fn.sum(
           eb.case()
             .when(eb.and([
               eb('employees.deleted_at', 'is', null),
-              eb.exists(
-                eb.selectFrom('employee_user')
-                  .select('employee_user.user_id')
-                  .whereRef('employee_user.employee_id', '=', 'employees.id')
-              )
+              this.hasLinkedLoginAccountSet(eb)
             ]))
             .then(1)
             .else(0)
@@ -318,8 +323,6 @@ export class EmployeeRepository {
   async getEmployeeById(id: number, userContext?: UserContext): Promise<EmployeeDetail | null> {
     const employee = await db
       .selectFrom('employees')
-      .leftJoin('employee_user', 'employees.id', 'employee_user.employee_id')
-      .leftJoin('users', 'employee_user.user_id', 'users.uid')
       .select([
         'employees.id',
         'employees.name',
@@ -339,11 +342,7 @@ export class EmployeeRepository {
         'employees.sales_id3',
         'employees.hidden_payroll',
         'employees.created_at',
-        'employees.deleted_at',
-        'users.uid as user_uid',
-        'users.email as user_email',
-        'users.role as user_role',
-        'users.created_at as user_created_at'
+        'employees.deleted_at'
       ])
       .where('employees.id', '=', id)
       .executeTakeFirst()
@@ -359,6 +358,10 @@ export class EmployeeRepository {
         return null
       }
     }
+
+    // Resolved separately so both linkage conventions are honoured — a join on
+    // employee_user alone reports "no user account" for ~93% of employees.
+    const user = await this.findPrimaryLoginAccount(db, id, employee.email)
 
     return {
       id: employee.id,
@@ -380,12 +383,12 @@ export class EmployeeRepository {
       hidden_payroll: Boolean(employee.hidden_payroll),
       created_at: employee.created_at,
       deleted_at: employee.deleted_at,
-      hasUser: Boolean(employee.user_uid),
-      user: employee.user_uid ? {
-        uid: employee.user_uid,
-        email: employee.user_email!,
-        role: employee.user_role!,
-        created_at: employee.user_created_at
+      hasUser: Boolean(user),
+      user: user ? {
+        uid: user.uid,
+        email: user.email,
+        role: user.role,
+        created_at: user.created_at
       } : undefined
     }
   }
@@ -400,7 +403,7 @@ export class EmployeeRepository {
       .insertInto('employees')
       .values({
         name: data.name,
-        email: data.email,
+        email: normalizeEmail(data.email),
         phone_no: data.phone_no || null,
         address: data.address,
         address_2: data.address_2 || null,
@@ -430,17 +433,30 @@ export class EmployeeRepository {
   }
 
   /**
-   * Update an existing employee
+   * Update an existing employee.
+   *
+   * The linked login account is kept in sync in the same transaction:
+   * - email goes to at most ONE user (`users.email` is UNIQUE, and the schema
+   *   allows an employee to have several linked accounts — writing the address
+   *   to all of them would deadlock on the index). The target is the account
+   *   whose address currently matches the employee's, else the lowest uid.
+   * - name goes to every linked account (no unique index on `users.name`).
+   * - nothing is written when the employee is soft-deleted: its login email is
+   *   parked and must stay parked (see softDeleteEmployee).
+   *
+   * A unique-index violation on `users.email` rolls the employees update back,
+   * so the two tables can never drift.
    */
   async updateEmployee(id: number, data: Partial<CreateEmployeeData>, userContext: UserContext): Promise<EmployeeDetail> {
     if (!userContext.isAdmin) throw new Error('Admin access required')
+
+    const normalizedEmail = data.email !== undefined ? normalizeEmail(data.email) : undefined
 
     const updateData: Record<string, unknown> = {
       updated_at: new Date()
     }
 
     if (data.name !== undefined) updateData.name = data.name
-    if (data.email !== undefined) updateData.email = data.email
     if (data.phone_no !== undefined) updateData.phone_no = data.phone_no || null
     if (data.address !== undefined) updateData.address = data.address
     if (data.address_2 !== undefined) updateData.address_2 = data.address_2 || null
@@ -456,11 +472,71 @@ export class EmployeeRepository {
     if (data.sales_id3 !== undefined) updateData.sales_id3 = data.sales_id3 || ''
     if (data.hidden_payroll !== undefined) updateData.hidden_payroll = data.hidden_payroll ? 1 : 0
 
-    await db
-      .updateTable('employees')
-      .set(updateData)
-      .where('id', '=', id)
-      .execute()
+    await db.transaction().execute(async (trx) => {
+      // Only look up the current identity when it could actually change.
+      const identityMayChange = normalizedEmail !== undefined || data.name !== undefined
+      const current = identityMayChange
+        ? await trx
+            .selectFrom('employees')
+            .select(['name', 'email', 'deleted_at'])
+            .where('id', '=', id)
+            .executeTakeFirst()
+        : undefined
+
+      const emailChanged =
+        current !== undefined &&
+        normalizedEmail !== undefined &&
+        normalizeEmail(current.email) !== normalizedEmail
+
+      // A soft-deleted employee's login email is parked and cannot be synced, so
+      // changing employees.email here would only re-create the drift this fix
+      // exists to remove. Callers must restore the employee first.
+      const emailWritable = emailChanged && !current?.deleted_at
+
+      // Only rewrite employees.email when it actually changes, so a legacy
+      // mixed-case address is not silently lowercased by an unrelated edit.
+      if (emailWritable) updateData.email = normalizedEmail
+
+      await trx
+        .updateTable('employees')
+        .set(updateData)
+        .where('id', '=', id)
+        .execute()
+
+      if (!current) return
+
+      // A soft-deleted employee's login email is parked; editing the employee
+      // record must not un-park it and re-enable the login.
+      if (current.deleted_at) return
+
+      const nameChanged = data.name !== undefined && current.name !== data.name
+      if (!emailChanged && !nameChanged) return
+
+      const linkedUsers = await this.getLinkedUsers(trx, id)
+      if (linkedUsers.length === 0) return
+
+      if (nameChanged) {
+        await trx
+          .updateTable('users')
+          .set({ name: data.name, updated_at: new Date() })
+          .where('uid', 'in', linkedUsers.map((user) => user.uid))
+          .execute()
+      }
+
+      if (emailChanged) {
+        const target = this.pickEmailSyncTarget(
+          linkedUsers,
+          id,
+          current.email,
+          normalizedEmail as string
+        )
+        await trx
+          .updateTable('users')
+          .set({ email: normalizedEmail, updated_at: new Date() })
+          .where('uid', '=', target.uid)
+          .execute()
+      }
+    })
 
     const updatedEmployee = await this.getEmployeeById(id)
     if (!updatedEmployee) {
@@ -471,41 +547,110 @@ export class EmployeeRepository {
   }
 
   /**
-   * Soft delete an employee
+   * Soft delete an employee.
+   *
+   * The linked login account(s) keep holding the email address on the
+   * `users_email_unique` index long after the employee is gone, which made the
+   * address impossible to reuse (and invisible in the admin UI). So in the same
+   * transaction every linked user's email is "parked" behind a
+   * `deleted-{employeeId}.` prefix and marked with `users.deleted_at`. Parking
+   * also disables the login, which is the intent for a deleted employee.
    */
   async softDeleteEmployee(id: number, userContext: UserContext): Promise<boolean> {
     if (!userContext.isAdmin) throw new Error('Admin access required')
 
-    const result = await db
-      .updateTable('employees')
-      .set({
-        is_active: 0,
-        deleted_at: new Date(),
-        updated_at: new Date()
-      })
-      .where('id', '=', id)
-      .execute()
+    return await db.transaction().execute(async (trx) => {
+      const now = new Date()
 
-    return result.length > 0
+      const result = await trx
+        .updateTable('employees')
+        .set({
+          is_active: 0,
+          deleted_at: now,
+          updated_at: now
+        })
+        .where('id', '=', id)
+        .execute()
+
+      const linkedUsers = await this.getLinkedUsers(trx, id)
+
+      for (const user of linkedUsers) {
+        const userUpdate: Record<string, unknown> = {
+          deleted_at: now,
+          updated_at: now
+        }
+
+        // Idempotent: re-deleting must never double-prefix an already parked address.
+        if (!isParkedEmail(user.email)) {
+          let parked = buildParkedEmail(id, user.email)
+          if (await this.emailTakenByOtherUser(trx, parked, user.uid)) {
+            parked = buildParkedEmail(id, user.email, user.uid)
+          }
+          userUpdate.email = parked
+        }
+
+        await trx
+          .updateTable('users')
+          .set(userUpdate)
+          .where('uid', '=', user.uid)
+          .execute()
+      }
+
+      return result.length > 0
+    })
   }
 
   /**
-   * Restore a soft-deleted employee
+   * Restore a soft-deleted employee.
+   *
+   * Un-parks each linked login email, but only when the original address is
+   * still free — otherwise the address stays parked and the admin fixes it by
+   * hand. Restoring the employee itself always succeeds.
    */
-  async restoreEmployee(id: number, userContext: UserContext): Promise<boolean> {
+  async restoreEmployee(id: number, userContext: UserContext): Promise<RestoreEmployeeResult> {
     if (!userContext.isAdmin) throw new Error('Admin access required')
 
-    const result = await db
-      .updateTable('employees')
-      .set({
-        is_active: 1,
-        deleted_at: null,
-        updated_at: new Date()
-      })
-      .where('id', '=', id)
-      .execute()
+    return await db.transaction().execute(async (trx) => {
+      const now = new Date()
 
-    return result.length > 0
+      const result = await trx
+        .updateTable('employees')
+        .set({
+          is_active: 1,
+          deleted_at: null,
+          updated_at: now
+        })
+        .where('id', '=', id)
+        .execute()
+
+      const linkedUsers = await this.getLinkedUsers(trx, id)
+      let emailsStillParked = 0
+
+      for (const user of linkedUsers) {
+        const original = unparkEmail(user.email, id, user.uid)
+
+        if (original === null) {
+          // Not parked by this employee: the account may have been retired
+          // independently (long before the employee was deleted), so its
+          // deleted_at is none of our business. Leave the row untouched.
+          continue
+        }
+
+        const owner = await this.findEmailOwnerWith(trx, original, id)
+        if (owner) {
+          emailsStillParked += 1
+          continue
+        }
+
+        await trx
+          .updateTable('users')
+          .set({ email: original, deleted_at: null, updated_at: now })
+          .where('uid', '=', user.uid)
+          .execute()
+      }
+
+      return { restored: result.length > 0, emailsStillParked }
+    })
   }
 
   /**
@@ -569,13 +714,15 @@ export class EmployeeRepository {
   ): Promise<EmployeeDetail> {
     if (!userContext.isAdmin) throw new Error('Admin access required')
 
+    const normalizedEmail = normalizeEmail(employeeData.email)
+
     return await db.transaction().execute(async (trx) => {
       // Create employee
       const employeeResult = await trx
         .insertInto('employees')
         .values({
           name: employeeData.name,
-          email: employeeData.email,
+          email: normalizedEmail,
           phone_no: employeeData.phone_no || null,
           address: employeeData.address,
           address_2: employeeData.address_2 || null,
@@ -606,7 +753,7 @@ export class EmployeeRepository {
           .values({
             id: employeeId,
             name: employeeData.name,
-            email: employeeData.email,
+            email: normalizedEmail,
             password: hashedPassword,
             role: userData.role || 'subscriber',
             created_at: new Date(),
@@ -780,27 +927,276 @@ export class EmployeeRepository {
   }
 
   /**
-   * Check if email is available for new employee/user
+   * Check if email is available for new employee/user.
+   *
+   * Thin wrapper over {@link findEmailOwner} so the boolean and the
+   * admin-facing conflict message can never disagree.
    */
   async isEmailAvailable(email: string, excludeEmployeeId?: number): Promise<boolean> {
-    let employeeQuery = db
+    return (await this.findEmailOwner(email, excludeEmployeeId)) === null
+  }
+
+  /**
+   * Find who currently holds an email address, or null when it is free.
+   *
+   * Scoping rules:
+   * - `employees`: soft-deleted rows never block (their address is reusable);
+   *   inactive-but-not-deleted rows still do — they are real, visible records.
+   * - `users`: every remaining row blocks (the UNIQUE index makes those genuine
+   *   conflicts) except the accounts linked to `excludeEmployeeId`, which are
+   *   the record being edited.
+   */
+  async findEmailOwner(email: string, excludeEmployeeId?: number): Promise<EmailOwnerInfo | null> {
+    return this.findEmailOwnerWith(db, email, excludeEmployeeId)
+  }
+
+  private async findEmailOwnerWith(
+    executor: DbExecutor,
+    email: string,
+    excludeEmployeeId?: number
+  ): Promise<EmailOwnerInfo | null> {
+    const normalized = normalizeEmail(email)
+
+    let employeeQuery = executor
       .selectFrom('employees')
-      .select('id')
-      .where('email', '=', email)
+      .select(['id', 'name'])
+      .where('email', '=', normalized)
+      .where('deleted_at', 'is', null)
 
     if (excludeEmployeeId) {
       employeeQuery = employeeQuery.where('id', '!=', excludeEmployeeId)
     }
 
     const existingEmployee = await employeeQuery.executeTakeFirst()
-    if (existingEmployee) return false
+    if (existingEmployee) {
+      return {
+        source: 'employee',
+        employeeId: existingEmployee.id,
+        employeeName: existingEmployee.name,
+        employeeDeleted: false
+      }
+    }
 
-    const existingUser = await db
+    let userQuery = executor
+      .selectFrom('users')
+      .select(['users.uid', 'users.id'])
+      .where('users.email', '=', normalized)
+      .orderBy('users.uid', 'asc')
+
+    if (excludeEmployeeId) {
+      // Exclude every login account linked to the employee being edited — by
+      // EITHER convention, or the employee's own legacy login looks like a
+      // stranger holding its address.
+      userQuery = userQuery.where((eb) =>
+        eb.not(this.isLinkedLoginAccount(eb, excludeEmployeeId))
+      )
+    }
+
+    const existingUser = await userQuery.executeTakeFirst()
+    if (!existingUser) return null
+
+    const owner = await this.resolveEmployeeForUser(
+      executor,
+      existingUser.uid,
+      existingUser.id
+    )
+
+    return {
+      source: 'user',
+      employeeId: owner?.id ?? null,
+      employeeName: owner?.name ?? null,
+      employeeDeleted: Boolean(owner?.deleted_at)
+    }
+  }
+
+  /**
+   * Which linked login account should carry the employee's email address.
+   *
+   * `users.email` is UNIQUE, so exactly one account can hold it. Preference
+   * order, most to least specific:
+   *  1. an account that already holds the NEW address — makes the write
+   *     idempotent instead of dead-ending on a 1062 against a sibling account;
+   *  2. the account holding the employee's PREVIOUS address — the normal case;
+   *  3. an account whose address is parked by this employee — the address is
+   *     ours to reclaim (e.g. after a restore that could not un-park);
+   *  4. the lowest uid, so the choice is stable across calls.
+   */
+  private pickEmailSyncTarget(
+    linkedUsers: Array<{ uid: number; email: string }>,
+    employeeId: number,
+    previousEmployeeEmail: string,
+    newEmail: string
+  ): { uid: number; email: string } {
+    const previous = normalizeEmail(previousEmployeeEmail)
+    const next = normalizeEmail(newEmail)
+
+    return (
+      linkedUsers.find((user) => normalizeEmail(user.email) === next) ??
+      linkedUsers.find((user) => normalizeEmail(user.email) === previous) ??
+      linkedUsers.find((user) => unparkEmail(user.email, employeeId, user.uid) !== null) ??
+      linkedUsers.reduce((lowest, user) => (user.uid < lowest.uid ? user : lowest))
+    )
+  }
+
+  /**
+   * THE definition of "this employee's login account(s)".
+   *
+   * The database carries two linkage conventions and production data uses both:
+   *  - the `employee_user` junction table (105 rows), and
+   *  - the legacy Laravel convention `users.id = employees.id` (~1149 rows),
+   *    which is how NextAuth itself resolves the employee at sign-in.
+   * Over 500 active employees have only the legacy link, so anything that
+   * consults just the junction table silently misses ~93% of logins.
+   *
+   * `users.id` is a plain, non-unique int column (`uid` is the PK), so this can
+   * legitimately match several rows — callers must handle a set. `id > 0` keeps
+   * an unset/zero column from matching a real employee.
+   *
+   * Pass a number for a known employee, or `eb.ref('employees.id')` to correlate
+   * against an enclosing `employees` query.
+   */
+  private isLinkedLoginAccount(
+    eb: ExpressionBuilder<DB, 'users'>,
+    employee: number | Expression<number>
+  ) {
+    return eb.or([
+      eb.exists(
+        eb.selectFrom('employee_user as own_link')
+          .select('own_link.user_id')
+          .whereRef('own_link.user_id', '=', 'users.uid')
+          .where('own_link.employee_id', '=', employee)
+      ),
+      eb.and([
+        eb('users.id', '=', employee),
+        eb('users.id', '>', 0),
+        // The junction table wins when the two conventions disagree: a row
+        // bound to employee A by employee_user is A's login even if its
+        // users.id happens to point at employee B. Without this, B's edit
+        // could clobber A's login credentials.
+        eb.not(
+          eb.exists(
+            eb.selectFrom('employee_user as other_link')
+              .select('other_link.user_id')
+              .whereRef('other_link.user_id', '=', 'users.uid')
+              .where('other_link.employee_id', '!=', employee)
+          )
+        )
+      ])
+    ])
+  }
+
+  /**
+   * Set-oriented form of the same relation, for queries that ask "which
+   * employees have a login at all" across the whole table.
+   *
+   * The correlated EXISTS form is ~400x slower here because `users.id` carries
+   * no index (measured on the prod snapshot: stats 0.98ms → 391ms, hasUser
+   * filter ~1ms → 548ms, and the admin employees page runs both per load
+   * through a connection pool of 1). These uncorrelated IN-subqueries are
+   * materialised once and measured at ~1ms with identical results.
+   *
+   * Deliberately coarser than {@link isLinkedLoginAccount}: it does not apply
+   * the junction-wins tie-break, so an employee whose only candidate account is
+   * junction-owned by someone else still shows the flag. This is a display
+   * hint; every write path resolves through the authoritative form.
+   */
+  private hasLinkedLoginAccountSet(eb: ExpressionBuilder<DB, 'employees'>) {
+    return eb.or([
+      eb('employees.id', 'in',
+        eb.selectFrom('users').select('users.id').where('users.id', '>', 0)
+      ),
+      eb('employees.id', 'in',
+        eb.selectFrom('employee_user').select('employee_user.employee_id')
+      )
+    ])
+  }
+
+  /**
+   * Every login account linked to an employee, by either convention, deduped by
+   * uid (selecting from `users` alone cannot fan out) and ordered for stability.
+   */
+  private async getLinkedUsers(
+    executor: DbExecutor,
+    employeeId: number
+  ): Promise<Array<{ uid: number; id: number; email: string; role: string; created_at: Date | null }>> {
+    return await executor
+      .selectFrom('users')
+      .select(['users.uid', 'users.id', 'users.email', 'users.role', 'users.created_at'])
+      .where((eb) => this.isLinkedLoginAccount(eb, employeeId))
+      .orderBy('users.uid', 'asc')
+      .execute()
+  }
+
+  /**
+   * The login account shown on the employee detail page.
+   *
+   * Prefers the account whose address matches the employee's (mirroring
+   * pickEmailSyncTarget) — otherwise an employee with several linked accounts
+   * shows a long-retired one just because it has the lower uid.
+   */
+  private async findPrimaryLoginAccount(
+    executor: DbExecutor,
+    employeeId: number,
+    employeeEmail: string
+  ) {
+    const accounts = await this.getLinkedUsers(executor, employeeId)
+    if (accounts.length === 0) return undefined
+
+    const wanted = normalizeEmail(employeeEmail)
+    return accounts.find((account) => normalizeEmail(account.email) === wanted) ?? accounts[0]
+  }
+
+  /**
+   * Which employee owns a login account: the junction table first, then the
+   * legacy `users.id = employees.id` convention. Only when neither resolves is
+   * the account genuinely unlinked.
+   */
+  private async resolveEmployeeForUser(
+    executor: DbExecutor,
+    uid: number,
+    usersId: number
+  ): Promise<{ id: number; name: string; deleted_at: Date | null } | undefined> {
+    const viaJunction = await executor
+      .selectFrom('employee_user')
+      .innerJoin('employees', 'employees.id', 'employee_user.employee_id')
+      .select(['employees.id', 'employees.name', 'employees.deleted_at'])
+      .where('employee_user.user_id', '=', uid)
+      .executeTakeFirst()
+
+    if (viaJunction) return viaJunction
+    if (!usersId || usersId <= 0) return undefined
+
+    return await executor
+      .selectFrom('employees')
+      .select(['id', 'name', 'deleted_at'])
+      .where('id', '=', usersId)
+      .executeTakeFirst()
+  }
+
+  /** Guard against a parked value colliding with an unrelated login account. */
+  private async emailTakenByOtherUser(
+    executor: DbExecutor,
+    email: string,
+    excludeUid: number
+  ): Promise<boolean> {
+    const row = await executor
       .selectFrom('users')
       .select('uid')
       .where('email', '=', email)
+      .where('uid', '!=', excludeUid)
       .executeTakeFirst()
 
-    return !existingUser
+    return Boolean(row)
   }
+}
+
+/**
+ * True for a MySQL/MariaDB duplicate-key error (errno 1062). Used to turn the
+ * race between the availability check and the write into the same 400 conflict
+ * the pre-check produces.
+ */
+export function isDuplicateEmailError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const candidate = error as { code?: unknown; errno?: unknown }
+  return candidate.code === 'ER_DUP_ENTRY' || candidate.errno === 1062
 }

--- a/src/lib/repositories/__tests__/EmployeeRepository.email-sql.test.ts
+++ b/src/lib/repositories/__tests__/EmployeeRepository.email-sql.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Compile-only SQL assertions.
+ *
+ * The behavioural tests in EmployeeRepository.email.test.ts drive a hand-rolled
+ * chainable mock, which cannot see *inside* the predicates the repository
+ * builds — deleting a correlated filter would still pass them. Here the
+ * repository runs against a real Kysely instance wired to a compile-only driver,
+ * so the emitted MySQL is asserted verbatim.
+ */
+/* eslint-disable no-var */
+var capturedSql: string[]
+/* eslint-enable no-var */
+
+jest.mock('@/lib/database/client', () => {
+  const {
+    Kysely,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+    DummyDriver,
+  } = jest.requireActual('kysely')
+
+  capturedSql = []
+
+  return {
+    db: new Kysely({
+      dialect: {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => new DummyDriver(),
+        createIntrospector: (kysely: never) => new MysqlIntrospector(kysely),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      },
+      log: (event: { level: string; query: { sql: string } }) => {
+        if (event.level === 'query') capturedSql.push(event.query.sql)
+      },
+    }),
+  }
+})
+
+import { EmployeeRepository } from '../EmployeeRepository'
+
+describe('EmployeeRepository — emitted SQL', () => {
+  let repo: EmployeeRepository
+
+  beforeEach(() => {
+    capturedSql.length = 0
+    repo = new EmployeeRepository()
+  })
+
+  describe('findEmailOwner', () => {
+    it('scopes the employees lookup to live rows and excludes the edited employee', async () => {
+      await repo.findEmailOwner('test@gmail.com', 1252)
+
+      const employeeSql = capturedSql[0]
+      expect(employeeSql).toContain('from `employees`')
+      expect(employeeSql).toContain('`email` = ?')
+      expect(employeeSql).toContain('`deleted_at` is null')
+      expect(employeeSql).toContain('`id` != ?')
+    })
+
+    it("excludes the edited employee's own login accounts under BOTH linkage conventions", async () => {
+      await repo.findEmailOwner('test@gmail.com', 1252)
+
+      const usersSql = capturedSql[1]
+      expect(usersSql).toContain('from `users`')
+      expect(usersSql).toContain('not (')
+      expect(usersSql).toContain('from `employee_user` as `own_link`')
+      // The junction half: correlation to the outer users row...
+      expect(usersSql).toContain('`own_link`.`user_id` = `users`.`uid`')
+      // ...and the restriction to the employee being edited. Dropping this one
+      // would exclude EVERY linked account and let real conflicts through.
+      expect(usersSql).toContain('`own_link`.`employee_id` = ?')
+      // The legacy half: users.id = employees.id is how NextAuth resolves the
+      // employee, and how ~93% of production logins are linked. Without it the
+      // employee's own login looks like a stranger holding its address.
+      expect(usersSql).toContain('`users`.`id` = ?')
+      expect(usersSql).toContain('`users`.`id` > ?')
+      // The legacy arm yields to the junction table when they disagree: a row
+      // bound to another employee by employee_user is not this employee's login.
+      expect(usersSql).toContain('from `employee_user` as `other_link`')
+      expect(usersSql).toContain('`other_link`.`employee_id` != ?')
+      // The two halves are alternatives, not both-required.
+      expect(usersSql).toMatch(/not \(exists \(.*\) or \(.*`users`\.`id` = \?.*\)\)/)
+    })
+
+    it('applies no exclusion when there is no employee to exclude', async () => {
+      await repo.findEmailOwner('test@gmail.com')
+
+      const usersSql = capturedSql[1]
+      expect(usersSql).toContain('from `users`')
+      expect(usersSql).not.toContain('not (')
+      expect(usersSql).not.toContain('own_link')
+    })
+
+    it('attributes ownership through employee_user first, then users.id', async () => {
+      // The dummy driver returns no rows, so drive attribution directly.
+      const resolve = (repo as unknown as {
+        resolveEmployeeForUser: (executor: unknown, uid: number, usersId: number) => Promise<unknown>
+      }).resolveEmployeeForUser.bind(repo)
+
+      const { db } = jest.requireMock('@/lib/database/client')
+      capturedSql.length = 0
+      await resolve(db, 1250, 1256)
+
+      // Junction lookup first...
+      expect(capturedSql[0]).toContain('from `employee_user`')
+      expect(capturedSql[0]).toContain('inner join `employees` on `employees`.`id` = `employee_user`.`employee_id`')
+      expect(capturedSql[0]).toContain('`employee_user`.`user_id` = ?')
+      // ...then the legacy users.id = employees.id fallback.
+      expect(capturedSql[1]).toContain('from `employees`')
+      expect(capturedSql[1]).toContain('`id` = ?')
+    })
+
+    it('never resolves a legacy owner for a zero/unset users.id', async () => {
+      const resolve = (repo as unknown as {
+        resolveEmployeeForUser: (executor: unknown, uid: number, usersId: number) => Promise<unknown>
+      }).resolveEmployeeForUser.bind(repo)
+
+      const { db } = jest.requireMock('@/lib/database/client')
+      capturedSql.length = 0
+      await resolve(db, 1250, 0)
+
+      // Junction lookup only — employees.id 0 cannot exist, so no second query.
+      expect(capturedSql).toHaveLength(1)
+      expect(capturedSql[0]).toContain('from `employee_user`')
+    })
+  })
+
+  describe('linked-login relation reuse', () => {
+    it('uses uncorrelated semi-joins for the hasUser flag and filter', async () => {
+      // `users.id` has no index, so the correlated EXISTS form measured ~400x
+      // slower across the whole table (stats 0.98ms -> 391ms, filter ~1ms ->
+      // 548ms). These IN-subqueries are materialised once.
+      capturedSql.length = 0
+      await repo.getEmployees({ hasUser: true }, { employeeId: 1, isAdmin: true, isManager: false })
+
+      const semiJoin =
+        '(`employees`.`id` in (select `users`.`id` from `users` where `users`.`id` > ?) ' +
+        'or `employees`.`id` in (select `employee_user`.`employee_id` from `employee_user`))'
+
+      // The count query runs first, then the page query; both carry the filter.
+      const countSql = capturedSql[0]
+      const pageSql = capturedSql[capturedSql.length - 1]
+      expect(countSql).toContain(semiJoin)
+      expect(pageSql).toContain(semiJoin)
+      // ...and the flag in the select list uses the same shape.
+      expect(pageSql).toContain(`${semiJoin} as \`hasUser\``)
+      // No correlated EXISTS over users for the set-oriented parts.
+      expect(pageSql).not.toContain('exists (select `users`')
+    })
+
+    it('keeps the correlated form for the per-row emulation id', async () => {
+      capturedSql.length = 0
+      await repo.getEmployees({}, { employeeId: 1, isAdmin: true, isManager: false })
+
+      // This subquery runs once per returned row (page size), so correlating is
+      // the right trade — and it must resolve the exact account, guard included.
+      const pageSql = capturedSql[capturedSql.length - 1]
+      expect(pageSql).toContain('`own_link`.`employee_id` = `employees`.`id`')
+      expect(pageSql).toContain('`users`.`id` = `employees`.`id`')
+      expect(pageSql).toContain('`other_link`.`employee_id` != `employees`.`id`')
+      expect(pageSql).toContain('order by `users`.`uid` asc limit ?) as `user_id`')
+    })
+
+    it('uses the same semi-join for the withUserAccounts stat', async () => {
+      capturedSql.length = 0
+      await repo.getEmployeeStats({ employeeId: 1, isAdmin: true, isManager: false })
+
+      const statsSql = capturedSql[0]
+      expect(statsSql).toContain('`employees`.`id` in (select `users`.`id` from `users` where `users`.`id` > ?)')
+      expect(statsSql).toContain('`employees`.`id` in (select `employee_user`.`employee_id` from `employee_user`)')
+      expect(statsSql).not.toContain('exists (select `users`')
+    })
+
+    it('looks the detail-page employees row up without any user join', async () => {
+      capturedSql.length = 0
+      await repo.getEmployeeById(1252)
+
+      // The dummy driver returns no rows, so the lookup stops here — the point
+      // is that the employees row no longer depends on an employee_user join.
+      expect(capturedSql[0]).toContain('from `employees`')
+      expect(capturedSql[0]).not.toContain('join')
+    })
+
+    it('resolves the detail-page login account through both conventions', async () => {
+      const findPrimary = (repo as unknown as {
+        findPrimaryLoginAccount: (executor: unknown, employeeId: number, email: string) => Promise<unknown>
+      }).findPrimaryLoginAccount.bind(repo)
+
+      const { db } = jest.requireMock('@/lib/database/client')
+      capturedSql.length = 0
+      await findPrimary(db, 1252, 'chaise@example.com')
+
+      const userSql = capturedSql[0]
+      expect(userSql).toContain('from `users`')
+      expect(userSql).toContain('`own_link`.`employee_id` = ?')
+      expect(userSql).toContain('`users`.`id` = ?')
+      expect(userSql).toContain('`users`.`id` > ?')
+      expect(userSql).toContain('order by `users`.`uid` asc')
+    })
+
+    it('returns every linked account, by either convention, deduped and ordered', async () => {
+      const getLinked = (repo as unknown as {
+        getLinkedUsers: (executor: unknown, employeeId: number) => Promise<unknown>
+      }).getLinkedUsers.bind(repo)
+
+      const { db } = jest.requireMock('@/lib/database/client')
+      capturedSql.length = 0
+      await getLinked(db, 79)
+
+      const sql = capturedSql[0]
+      // Selecting from `users` alone: no join fan-out, so uids are unique by
+      // construction — no DISTINCT needed even though users.id is non-unique.
+      expect(sql).toContain(
+        'select `users`.`uid`, `users`.`id`, `users`.`email`, `users`.`role`, `users`.`created_at` from `users`'
+      )
+      expect(sql).not.toContain('join')
+      expect(sql).toContain('exists')
+      expect(sql).toContain('`own_link`.`employee_id` = ?')
+      expect(sql).toContain('`users`.`id` = ?')
+      // Junction-wins guard travels with the relation.
+      expect(sql).toContain('`other_link`.`employee_id` != ?')
+      expect(sql).toContain('order by `users`.`uid` asc')
+    })
+  })
+})

--- a/src/lib/repositories/__tests__/EmployeeRepository.email.test.ts
+++ b/src/lib/repositories/__tests__/EmployeeRepository.email.test.ts
@@ -1,0 +1,820 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- chainable db test mock is intentionally untyped */
+import type { UserContext } from '@/lib/auth/types'
+
+type Row = Record<string, unknown>
+
+interface SelectCall {
+  table: string
+  joins: string[]
+  wheres: unknown[][]
+}
+
+interface UpdateCall {
+  table: string
+  values: Row
+  wheres: unknown[][]
+}
+
+/**
+ * Table-aware chainable db mock.
+ *
+ * `queueSelect(table, rows)` feeds the *next* `selectFrom(table)` (the last
+ * queued entry sticks, so a table queried once can be primed once). Update
+ * statements are recorded per table and can be made to throw, which is how the
+ * `users_email_unique` race is simulated.
+ *
+ * Must use `var` so jest.mock hoisting doesn't hit the temporal dead zone.
+ */
+/* eslint-disable no-var */
+var selectCalls: SelectCall[]
+var updateCalls: UpdateCall[]
+var selectQueues: Map<string, Row[][]>
+var updateErrors: Map<string, unknown>
+var transactionSpy: jest.Mock
+/* eslint-enable no-var */
+
+jest.mock('@/lib/database/client', () => {
+  selectCalls = []
+  updateCalls = []
+  selectQueues = new Map()
+  updateErrors = new Map()
+
+  function nextRows(table: string): Row[] {
+    const queue = selectQueues.get(table)
+    if (!queue || queue.length === 0) return []
+    return queue.length === 1 ? queue[0] : (queue.shift() as Row[])
+  }
+
+  function makeSelectChain(table: string) {
+    const record: SelectCall = { table, joins: [], wheres: [] }
+    selectCalls.push(record)
+
+    const chain: any = {
+      select: jest.fn(() => chain),
+      selectAll: jest.fn(() => chain),
+      innerJoin: jest.fn((joined: string) => {
+        record.joins.push(joined)
+        return chain
+      }),
+      leftJoin: jest.fn((joined: string) => {
+        record.joins.push(joined)
+        return chain
+      }),
+      where: jest.fn((...args: unknown[]) => {
+        record.wheres.push(args)
+        return chain
+      }),
+      whereRef: jest.fn(() => chain),
+      orderBy: jest.fn(() => chain),
+      limit: jest.fn(() => chain),
+      offset: jest.fn(() => chain),
+      execute: jest.fn(async () => nextRows(table)),
+      executeTakeFirst: jest.fn(async () => nextRows(table)[0]),
+      executeTakeFirstOrThrow: jest.fn(async () => {
+        const row = nextRows(table)[0]
+        if (!row) throw new Error(`no row for ${table}`)
+        return row
+      }),
+    }
+    return chain
+  }
+
+  function makeUpdateChain(table: string) {
+    const record: UpdateCall = { table, values: {}, wheres: [] }
+
+    const chain: any = {
+      set: jest.fn((values: Row) => {
+        record.values = values
+        return chain
+      }),
+      where: jest.fn((...args: unknown[]) => {
+        record.wheres.push(args)
+        return chain
+      }),
+      execute: jest.fn(async () => {
+        updateCalls.push(record)
+        const error = updateErrors.get(table)
+        if (error) throw error
+        return [{ numUpdatedRows: BigInt(1) }]
+      }),
+    }
+    return chain
+  }
+
+  const dbMock: any = {
+    selectFrom: jest.fn((table: string) => makeSelectChain(table)),
+    updateTable: jest.fn((table: string) => makeUpdateChain(table)),
+    insertInto: jest.fn(() => ({
+      values: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue([]),
+      executeTakeFirstOrThrow: jest.fn().mockResolvedValue({ insertId: BigInt(1) }),
+    })),
+    fn: { count: jest.fn().mockReturnValue({ as: jest.fn() }) },
+    case: jest.fn(),
+  }
+
+  transactionSpy = jest.fn().mockReturnValue({
+    execute: jest.fn((fn: any) => fn(dbMock)),
+  })
+  dbMock.transaction = transactionSpy
+
+  return { db: dbMock }
+})
+
+jest.mock('bcryptjs', () => ({ hash: jest.fn().mockResolvedValue('hashed_password') }))
+
+import { EmployeeRepository, isDuplicateEmailError } from '../EmployeeRepository'
+import { emailConflictMessage, isParkTooLongError } from '@/lib/utils/email'
+
+const adminCtx: UserContext = { employeeId: 1, isAdmin: true, isManager: false }
+
+function queueSelect(table: string, rows: Row[]) {
+  const queue = selectQueues.get(table) ?? []
+  queue.push(rows)
+  selectQueues.set(table, queue)
+}
+
+/**
+ * Queue the result of the linked-login lookup. `getLinkedUsers` selects from
+ * `users` (union of the employee_user junction AND the legacy
+ * users.id = employees.id convention), never from the junction table alone.
+ */
+function queueLinkedUsers(rows: Row[]) {
+  queueSelect('users', rows)
+}
+
+function selectsFor(table: string) {
+  return selectCalls.filter((call) => call.table === table)
+}
+
+function updatesFor(table: string) {
+  return updateCalls.filter((call) => call.table === table)
+}
+
+/** Flatten the simple `where(col, op, value)` triples recorded for a call. */
+function whereTriples(call: SelectCall | UpdateCall) {
+  return call.wheres.filter((args) => typeof args[0] === 'string')
+}
+
+/** Run the function-valued where() predicates through a recording expression builder. */
+function ebRecordsFor(call: SelectCall) {
+  const records: string[] = []
+  const sub: any = {}
+  sub.select = jest.fn(() => sub)
+  // Subquery predicates are recorded too, so the correlation and the
+  // junction-wins guard inside the EXISTS arms are assertable.
+  sub.where = jest.fn((...args: unknown[]) => {
+    records.push(`cmp:${String(args[0])} ${String(args[1])}`)
+    return sub
+  })
+  sub.whereRef = jest.fn((...args: unknown[]) => {
+    records.push(`ref:${String(args[0])} ${String(args[1])} ${String(args[2])}`)
+    return sub
+  })
+
+  const eb: any = (...args: unknown[]) => {
+    records.push(`cmp:${String(args[0])} ${String(args[1])}`)
+    return { __cmp: args }
+  }
+  eb.not = (x: unknown) => {
+    records.push('not')
+    return { __not: x }
+  }
+  eb.or = (parts: unknown[]) => {
+    records.push('or')
+    return { __or: parts }
+  }
+  eb.and = (parts: unknown[]) => {
+    records.push('and')
+    return { __and: parts }
+  }
+  eb.exists = (x: unknown) => {
+    records.push('exists')
+    return { __exists: x }
+  }
+  eb.selectFrom = (table: string) => {
+    records.push(`selectFrom:${table}`)
+    return sub
+  }
+
+  for (const args of call.wheres) {
+    if (typeof args[0] === 'function') (args[0] as any)(eb)
+  }
+  return records
+}
+
+const detailRow = {
+  id: 1252, name: 'Chaise Scott', email: 'test@gmail.com', phone_no: null,
+  address: '123 St', address_2: null, city: null, state: null,
+  postal_code: null, country: 'US', is_active: 1, is_admin: 0, is_mgr: 0,
+  sales_id1: '', sales_id2: '', sales_id3: '', hidden_payroll: 0,
+  created_at: new Date(), deleted_at: null,
+  user_uid: 1250, user_email: 'test@gmail.com', user_role: 'subscriber',
+  user_created_at: null,
+}
+
+describe('EmployeeRepository email identity', () => {
+  let repo: EmployeeRepository
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    selectCalls.length = 0
+    updateCalls.length = 0
+    selectQueues.clear()
+    updateErrors.clear()
+    repo = new EmployeeRepository()
+  })
+
+  describe('isEmailAvailable / findEmailOwner scoping', () => {
+    it('a soft-deleted employee no longer blocks the address', async () => {
+      // The employees lookup filters `deleted_at IS NULL`, so the deleted row is
+      // never returned; nothing else holds the address.
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      await expect(repo.isEmailAvailable('test@gmail.com')).resolves.toBe(true)
+
+      const employeeSelect = selectsFor('employees')[0]
+      expect(whereTriples(employeeSelect)).toContainEqual(['deleted_at', 'is', null])
+    })
+
+    it('an inactive-but-not-deleted employee still blocks the address', async () => {
+      queueSelect('employees', [{ id: 900, name: 'Inactive Ida' }])
+
+      await expect(repo.isEmailAvailable('ida@example.com')).resolves.toBe(false)
+
+      // No `is_active` filter — inactive records are still real, visible records.
+      const filtered = whereTriples(selectsFor('employees')[0]).map((args) => args[0])
+      expect(filtered).not.toContain('is_active')
+    })
+
+    it("excludes the edited employee's own linked login account", async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      await expect(repo.isEmailAvailable('test@gmail.com', 1252)).resolves.toBe(true)
+
+      expect(whereTriples(selectsFor('employees')[0])).toContainEqual(['id', '!=', 1252])
+
+      // The users lookup excludes accounts linked to 1252 under BOTH conventions.
+      const records = ebRecordsFor(selectsFor('users')[0])
+      expect(records).toContain('not')
+      expect(records).toContain('or')
+      // ...the employee_user junction half...
+      expect(records).toContain('exists')
+      expect(records).toContain('selectFrom:employee_user as own_link')
+      // ...and the legacy users.id = employees.id half.
+      expect(records).toContain('cmp:users.id =')
+      expect(records).toContain('cmp:users.id >')
+      expect(records).toContain('ref:own_link.user_id = users.uid')
+    })
+
+    it('yields to the junction table when the two conventions disagree', async () => {
+      // A row junction-linked to employee A whose users.id points at employee B
+      // belongs to A only — otherwise B's edit could clobber A's credentials.
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      await repo.isEmailAvailable('shared@example.com', 500)
+
+      const records = ebRecordsFor(selectsFor('users')[0])
+      expect(records).toContain('selectFrom:employee_user as other_link')
+      expect(records).toContain('cmp:other_link.employee_id !=')
+    })
+
+    it('a login account not linked to any employee still blocks', async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [
+        { uid: 77, employee_id: null, employee_name: null, employee_deleted_at: null },
+      ])
+
+      await expect(repo.isEmailAvailable('orphan@example.com', 1252)).resolves.toBe(false)
+    })
+
+    it("another employee's linked login account still blocks", async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [
+        { uid: 1250, employee_id: 1256, employee_name: 'Chaise Scott', employee_deleted_at: null },
+      ])
+
+      await expect(repo.isEmailAvailable('chaises34@gmail.com', 1252)).resolves.toBe(false)
+    })
+
+    it('normalizes the address before comparing (MySQL is case-insensitive)', async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      await repo.isEmailAvailable('  Test@GMAIL.com ')
+
+      expect(whereTriples(selectsFor('employees')[0])).toContainEqual(['email', '=', 'test@gmail.com'])
+      expect(whereTriples(selectsFor('users')[0])).toContainEqual(['users.email', '=', 'test@gmail.com'])
+    })
+  })
+
+  describe('getEmployeeById — which login account is shown', () => {
+    const employeeRow = {
+      id: 79, name: 'Sabian Ayers', email: 'sabianelayers@yahoo.com', phone_no: null,
+      address: '1 St', address_2: null, city: null, state: null, postal_code: null,
+      country: 'US', is_active: 0, is_admin: 0, is_mgr: 0, sales_id1: '', sales_id2: '',
+      sales_id3: '', hidden_payroll: 0, created_at: new Date(), deleted_at: null,
+    }
+
+    it('prefers the account whose address matches the employee, not the lowest uid', async () => {
+      // Employee 79 in production: uid 74 (retired in 2017) sorts first, but uid
+      // 91 is the account that actually carries the employee's address.
+      queueSelect('employees', [employeeRow])
+      queueLinkedUsers([
+        { uid: 74, id: 79, email: 'sabianelayers@gmail.com', role: 'subscriber', created_at: null },
+        { uid: 91, id: 79, email: 'sabianelayers@yahoo.com', role: 'subscriber', created_at: null },
+      ])
+
+      const detail = await repo.getEmployeeById(79)
+
+      expect(detail?.hasUser).toBe(true)
+      expect(detail?.user?.uid).toBe(91)
+      expect(detail?.user?.email).toBe('sabianelayers@yahoo.com')
+    })
+
+    it('falls back to the lowest uid when no account matches the address', async () => {
+      queueSelect('employees', [employeeRow])
+      queueLinkedUsers([
+        { uid: 74, id: 79, email: 'old@gmail.com', role: 'subscriber', created_at: null },
+        { uid: 91, id: 79, email: 'other@gmail.com', role: 'author', created_at: null },
+      ])
+
+      const detail = await repo.getEmployeeById(79)
+
+      expect(detail?.user?.uid).toBe(74)
+    })
+
+    it('reports no account when nothing is linked by either convention', async () => {
+      queueSelect('employees', [employeeRow])
+      queueLinkedUsers([])
+
+      const detail = await repo.getEmployeeById(79)
+
+      expect(detail?.hasUser).toBe(false)
+      expect(detail?.user).toBeUndefined()
+    })
+  })
+
+  describe('findEmailOwner message variants', () => {
+    it('live employee row', async () => {
+      queueSelect('employees', [{ id: 123, name: 'Jane Doe' }])
+
+      const owner = await repo.findEmailOwner('jane@example.com')
+
+      expect(owner).toEqual({
+        source: 'employee', employeeId: 123, employeeName: 'Jane Doe', employeeDeleted: false,
+      })
+      expect(emailConflictMessage(owner)).toBe(
+        'Email address is already in use by employee Jane Doe (#123).'
+      )
+    })
+
+    it('login account of a soft-deleted employee (junction-linked)', async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [{ uid: 1250, id: 0 }])
+      // Attribution step 1: employee_user join resolves the owner.
+      queueSelect('employee_user', [
+        { id: 1256, name: 'Chaise Scott', deleted_at: new Date('2026-01-01') },
+      ])
+
+      const owner = await repo.findEmailOwner('chaises34@gmail.com')
+
+      expect(owner).toEqual({
+        source: 'user', employeeId: 1256, employeeName: 'Chaise Scott', employeeDeleted: true,
+      })
+      // No "restore to release it" advice: restore only releases addresses this
+      // app parked, never a legacy row that was never parked.
+      expect(emailConflictMessage(owner)).toBe(
+        'Email address is already in use by the login account of deleted employee Chaise Scott (#1256).'
+      )
+    })
+
+    it('login account of a live employee', async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [{ uid: 42, id: 0 }])
+      queueSelect('employee_user', [{ id: 123, name: 'Jane Doe', deleted_at: null }])
+
+      const owner = await repo.findEmailOwner('jane@example.com')
+
+      expect(emailConflictMessage(owner)).toBe(
+        'Email address is already in use by the login account of employee Jane Doe (#123).'
+      )
+    })
+
+    it('login account linked only by the legacy users.id convention', async () => {
+      // The junction table has nothing for this account (the norm in production
+      // data), so attribution must fall through to users.id = employees.id.
+      // Before this fix the message read "not linked to any employee" — a
+      // dead-end for the admin.
+      queueSelect('employees', [])                 // nobody holds it in employees
+      queueSelect('users', [{ uid: 122, id: 124 }])
+      queueSelect('employee_user', [])             // no junction row
+      queueSelect('employees', [{ id: 124, name: 'Nancy Alvarez', deleted_at: null }])
+
+      const owner = await repo.findEmailOwner('alvareznancy26@gmail.com')
+
+      expect(owner).toEqual({
+        source: 'user', employeeId: 124, employeeName: 'Nancy Alvarez', employeeDeleted: false,
+      })
+      expect(emailConflictMessage(owner)).toBe(
+        'Email address is already in use by the login account of employee Nancy Alvarez (#124).'
+      )
+    })
+
+    it('login account with no employee link at all', async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [{ uid: 77, id: 0 }])
+      queueSelect('employee_user', [])
+
+      const owner = await repo.findEmailOwner('orphan@example.com')
+
+      expect(owner).toEqual({
+        source: 'user', employeeId: null, employeeName: null, employeeDeleted: false,
+      })
+      expect(emailConflictMessage(owner)).toBe(
+        'Email address is already in use by a login account not linked to any employee.'
+      )
+    })
+
+    it('returns null when the address is free', async () => {
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      await expect(repo.findEmailOwner('free@example.com')).resolves.toBeNull()
+      expect(emailConflictMessage(null)).toBe('Email address is already in use.')
+    })
+  })
+
+  describe('updateEmployee — user email sync', () => {
+    it('writes the new address to exactly ONE linked login account', async () => {
+      // Employee 79 in production has two linked users (uids 74 and 91). Writing
+      // the same address to both would trip users_email_unique.
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'old@gmail.com', deleted_at: null },
+      ])
+      queueLinkedUsers([
+        { uid: 91, email: 'old@gmail.com' },
+        { uid: 74, email: 'retired@gmail.com' },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { email: 'New@Gmail.com' }, adminCtx)
+
+      expect(transactionSpy).toHaveBeenCalled()
+      expect(updatesFor('employees')[0].values.email).toBe('new@gmail.com')
+
+      const userUpdates = updatesFor('users')
+      expect(userUpdates).toHaveLength(1)
+      expect(userUpdates[0].values.email).toBe('new@gmail.com')
+      // The account already carrying the employee's address wins, not the lowest uid.
+      expect(whereTriples(userUpdates[0])).toContainEqual(['uid', '=', 91])
+    })
+
+    it('syncs a login linked only by users.id, with no junction row', async () => {
+      // The common production shape: employee 124 ↔ user uid 122 via
+      // users.id = employees.id. The old junction-only lookup returned [] here,
+      // so the sync silently no-opped for ~93% of employees.
+      queueSelect('employees', [
+        { name: 'Nancy Alvarez', email: 'alvareznancy26@gmail.com', deleted_at: null },
+      ])
+      queueLinkedUsers([{ uid: 122, id: 124, email: 'alvareznancy26@gmail.com' }])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(124, { email: 'nancy.new@gmail.com' }, adminCtx)
+
+      const userUpdates = updatesFor('users')
+      expect(userUpdates).toHaveLength(1)
+      expect(userUpdates[0].values.email).toBe('nancy.new@gmail.com')
+      expect(whereTriples(userUpdates[0])).toContainEqual(['uid', '=', 122])
+      // The junction table is never consulted — the relation lives on `users`.
+      expect(selectsFor('employee_user')).toHaveLength(0)
+    })
+
+    it('prefers an account that already holds the NEW address (idempotent rewrite)', async () => {
+      // uid 74 already has the target address; writing it to uid 91 instead would
+      // dead-end on users_email_unique against its own sibling account.
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'old@gmail.com', deleted_at: null },
+      ])
+      queueLinkedUsers([
+        { uid: 91, email: 'old@gmail.com' },
+        { uid: 74, email: 'new@gmail.com' },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { email: 'New@Gmail.com' }, adminCtx)
+
+      const userUpdates = updatesFor('users')
+      expect(userUpdates).toHaveLength(1)
+      expect(whereTriples(userUpdates[0])).toContainEqual(['uid', '=', 74])
+    })
+
+    it('prefers an account parked by this employee over an unrelated one', async () => {
+      // After a restore that could not un-park, the address is still ours to
+      // reclaim — clobbering an unrelated sibling account would be wrong.
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'old@gmail.com', deleted_at: null },
+      ])
+      queueLinkedUsers([
+        { uid: 74, email: 'unrelated@gmail.com' },
+        { uid: 91, email: 'deleted-1252.something@gmail.com' },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { email: 'new@gmail.com' }, adminCtx)
+
+      const userUpdates = updatesFor('users')
+      expect(userUpdates).toHaveLength(1)
+      // Parked-by-us (91) wins over the lower uid (74).
+      expect(whereTriples(userUpdates[0])).toContainEqual(['uid', '=', 91])
+    })
+
+    it('falls back to the lowest uid when no linked account holds the old address', async () => {
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'old@gmail.com', deleted_at: null },
+      ])
+      queueLinkedUsers([
+        { uid: 91, email: 'someone@gmail.com' },
+        { uid: 74, email: 'other@gmail.com' },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { email: 'new@gmail.com' }, adminCtx)
+
+      const userUpdates = updatesFor('users')
+      expect(userUpdates).toHaveLength(1)
+      expect(whereTriples(userUpdates[0])).toContainEqual(['uid', '=', 74])
+    })
+
+    it('syncs users.name to EVERY linked account (no unique index on name)', async () => {
+      queueSelect('employees', [{ name: 'Old Name', email: 'old@gmail.com', deleted_at: null }])
+      queueLinkedUsers([
+        { uid: 91, email: 'old@gmail.com' },
+        { uid: 74, email: 'retired@gmail.com' },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { name: 'New Name' }, adminCtx)
+
+      const userUpdates = updatesFor('users')
+      expect(userUpdates).toHaveLength(1)
+      expect(userUpdates[0].values.name).toBe('New Name')
+      expect(userUpdates[0].values.email).toBeUndefined()
+      expect(whereTriples(userUpdates[0])).toContainEqual(['uid', 'in', [91, 74]])
+    })
+
+    it('writes nothing to users when the email (and name) are unchanged', async () => {
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'test@gmail.com', deleted_at: null },
+      ])
+      queueSelect('employees', [detailRow])
+
+      // Same address, different case — MySQL would treat these as equal too.
+      await repo.updateEmployee(1252, { email: 'TEST@gmail.com' }, adminCtx)
+
+      expect(updatesFor('users')).toHaveLength(0)
+      // Only getEmployeeById's login-account lookup — no linked-user sync lookup.
+      expect(selectsFor('users')).toHaveLength(1)
+    })
+
+    it('leaves a legacy mixed-case employees.email untouched when it did not change', async () => {
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'Chaise.Scott@Gmail.com', deleted_at: null },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { email: 'chaise.scott@gmail.com', city: 'Toledo' }, adminCtx)
+
+      const employeeUpdate = updatesFor('employees')[0]
+      expect(employeeUpdate.values.email).toBeUndefined()
+      expect(employeeUpdate.values.city).toBe('Toledo')
+    })
+
+    it('writes no email at all for a soft-deleted employee (no new drift)', async () => {
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'old@gmail.com', deleted_at: new Date('2026-01-01') },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { email: 'new@gmail.com', city: 'Toledo' }, adminCtx)
+
+      // The parked login email must not be rewritten (that re-enables login), and
+      // employees.email must not move either — that is exactly the drift this fix
+      // removes. Other fields still save.
+      expect(updatesFor('employees')[0].values.email).toBeUndefined()
+      expect(updatesFor('employees')[0].values.city).toBe('Toledo')
+      expect(updatesFor('users')).toHaveLength(0)
+      // Only getEmployeeById's login-account lookup — no linked-user sync lookup.
+      expect(selectsFor('users')).toHaveLength(1)
+    })
+
+    it('skips the users sync wholesale for a soft-deleted employee, name included', async () => {
+      queueSelect('employees', [
+        { name: 'Old Name', email: 'old@gmail.com', deleted_at: new Date('2026-01-01') },
+      ])
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { name: 'New Name' }, adminCtx)
+
+      expect(updatesFor('users')).toHaveLength(0)
+      // The employees row itself still saves normally.
+      expect(updatesFor('employees')[0].values.name).toBe('New Name')
+    })
+
+    it('does not touch users when only non-identity fields change', async () => {
+      queueSelect('employees', [detailRow])
+
+      await repo.updateEmployee(1252, { city: 'Toledo' }, adminCtx)
+
+      expect(updatesFor('users')).toHaveLength(0)
+    })
+
+    it('lets a users unique-index violation escape the transaction after the employees write', async () => {
+      queueSelect('employees', [
+        { name: 'Chaise Scott', email: 'old@gmail.com', deleted_at: null },
+      ])
+      queueLinkedUsers([{ uid: 1250, email: 'old@gmail.com' }])
+      const dupError = Object.assign(new Error('Duplicate entry'), {
+        code: 'ER_DUP_ENTRY', errno: 1062,
+      })
+      updateErrors.set('users', dupError)
+
+      await expect(
+        repo.updateEmployee(1252, { email: 'taken@gmail.com' }, adminCtx)
+      ).rejects.toBe(dupError)
+
+      // The employees write was attempted inside the same transaction callback and
+      // the error escapes it, so the real driver rolls that write back. (A mocked
+      // transaction cannot observe the rollback itself.)
+      expect(transactionSpy).toHaveBeenCalled()
+      expect(updatesFor('employees')).toHaveLength(1)
+      // ...and the route recognises the conflict.
+      expect(isDuplicateEmailError(dupError)).toBe(true)
+    })
+  })
+
+  describe('softDeleteEmployee — email parking', () => {
+    it('parks each linked login email and marks users.deleted_at', async () => {
+      queueLinkedUsers([{ uid: 1250, email: 'chaises34@gmail.com' }])
+      queueSelect('users', []) // parked value is free
+
+      await expect(repo.softDeleteEmployee(1256, adminCtx)).resolves.toBe(true)
+
+      const userUpdate = updatesFor('users')[0]
+      expect(userUpdate.values.email).toBe('deleted-1256.chaises34@gmail.com')
+      expect(userUpdate.values.deleted_at).toBeInstanceOf(Date)
+      expect(whereTriples(userUpdate)).toContainEqual(['uid', '=', 1250])
+
+      expect(updatesFor('employees')[0].values.deleted_at).toBeInstanceOf(Date)
+      expect(updatesFor('employees')[0].values.is_active).toBe(0)
+    })
+
+    it('parks a login linked only by users.id, with no junction row', async () => {
+      queueLinkedUsers([{ uid: 122, id: 124, email: 'alvareznancy26@gmail.com' }])
+      queueSelect('users', [])
+
+      await expect(repo.softDeleteEmployee(124, adminCtx)).resolves.toBe(true)
+
+      const userUpdate = updatesFor('users')[0]
+      expect(userUpdate.values.email).toBe('deleted-124.alvareznancy26@gmail.com')
+      expect(whereTriples(userUpdate)).toContainEqual(['uid', '=', 122])
+      expect(selectsFor('employee_user')).toHaveLength(0)
+    })
+
+    it('is idempotent — an already parked email is not double-prefixed', async () => {
+      queueLinkedUsers([{ uid: 1250, email: 'deleted-1256.chaises34@gmail.com' }])
+
+      await repo.softDeleteEmployee(1256, adminCtx)
+
+      const userUpdate = updatesFor('users')[0]
+      expect(userUpdate.values.email).toBeUndefined()
+      expect(userUpdate.values.deleted_at).toBeInstanceOf(Date)
+    })
+
+    it('falls back to the uid-qualified prefix when the parked value collides', async () => {
+      queueLinkedUsers([{ uid: 1250, email: 'chaises34@gmail.com' }])
+      queueSelect('users', [{ uid: 999 }]) // parked value already taken
+
+      await repo.softDeleteEmployee(1256, adminCtx)
+
+      expect(updatesFor('users')[0].values.email).toBe('deleted-1256-1250.chaises34@gmail.com')
+    })
+
+    it('aborts the delete rather than truncating an email too long to park', async () => {
+      // Truncation would silently corrupt the address restore later un-parks.
+      const longEmail = `${'a'.repeat(240)}@example.com`
+      queueLinkedUsers([{ uid: 1250, email: longEmail }])
+
+      const error = await repo.softDeleteEmployee(1256, adminCtx).catch((e) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).toMatch(/too long to park/i)
+      // Typed so the DELETE route can answer 400 instead of an opaque 500.
+      expect(isParkTooLongError(error)).toBe(true)
+      expect(isParkTooLongError(new Error('something else'))).toBe(false)
+      expect(updatesFor('users')).toHaveLength(0)
+    })
+
+    it('parks every linked account when more than one exists', async () => {
+      queueLinkedUsers([
+        { uid: 1250, email: 'a@example.com' },
+        { uid: 1251, email: 'b@example.com' },
+      ])
+      queueSelect('users', [])
+
+      await repo.softDeleteEmployee(1256, adminCtx)
+
+      expect(updatesFor('users').map((u) => u.values.email)).toEqual([
+        'deleted-1256.a@example.com',
+        'deleted-1256.b@example.com',
+      ])
+    })
+  })
+
+  describe('restoreEmployee — un-parking', () => {
+    it('un-parks the login email when the original address is free', async () => {
+      queueLinkedUsers([{ uid: 1250, email: 'deleted-1256.chaises34@gmail.com' }])
+      queueSelect('employees', []) // availability check: no employee holds it
+      queueSelect('users', [])     // availability check: no user holds it
+
+      const result = await repo.restoreEmployee(1256, adminCtx)
+
+      expect(result).toEqual({ restored: true, emailsStillParked: 0 })
+      const userUpdate = updatesFor('users')[0]
+      expect(userUpdate.values.email).toBe('chaises34@gmail.com')
+      expect(userUpdate.values.deleted_at).toBeNull()
+      expect(updatesFor('employees')[0].values.deleted_at).toBeNull()
+    })
+
+    it('leaves the email parked when the original address is taken', async () => {
+      queueLinkedUsers([{ uid: 1250, email: 'deleted-1256.chaises34@gmail.com' }])
+      queueSelect('employees', [{ id: 1252, name: 'Someone Else' }]) // address reused
+
+      const result = await repo.restoreEmployee(1256, adminCtx)
+
+      // Restore still succeeds; the admin fixes the address by hand.
+      expect(result).toEqual({ restored: true, emailsStillParked: 1 })
+      expect(updatesFor('users')).toHaveLength(0)
+    })
+
+    it('leaves a linked account we never parked completely untouched', async () => {
+      // uid 74 was retired in 2017, long before the employee was deleted in 2020 —
+      // restoring the employee must not resurrect that account.
+      queueLinkedUsers([{ uid: 74, email: 'retired@gmail.com' }])
+
+      const result = await repo.restoreEmployee(1256, adminCtx)
+
+      expect(result).toEqual({ restored: true, emailsStillParked: 0 })
+      expect(updatesFor('users')).toHaveLength(0)
+      // No availability lookup needed for an address that was never parked.
+      expect(selectsFor('employees')).toHaveLength(0)
+    })
+
+    it('clears deleted_at only on the rows it un-parks', async () => {
+      queueLinkedUsers([
+        { uid: 74, email: 'retired@gmail.com' },
+        { uid: 91, email: 'deleted-1256.chaises34@gmail.com' },
+      ])
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      await repo.restoreEmployee(1256, adminCtx)
+
+      const userUpdates = updatesFor('users')
+      expect(userUpdates).toHaveLength(1)
+      expect(whereTriples(userUpdates[0])).toContainEqual(['uid', '=', 91])
+      expect(userUpdates[0].values.deleted_at).toBeNull()
+    })
+
+    it('un-parks a login linked only by users.id', async () => {
+      queueLinkedUsers([{ uid: 122, id: 124, email: 'deleted-124.alvareznancy26@gmail.com' }])
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      const result = await repo.restoreEmployee(124, adminCtx)
+
+      expect(result).toEqual({ restored: true, emailsStillParked: 0 })
+      expect(updatesFor('users')[0].values.email).toBe('alvareznancy26@gmail.com')
+      expect(selectsFor('employee_user')).toHaveLength(0)
+    })
+
+    it('un-parks the uid-qualified fallback prefix too', async () => {
+      queueLinkedUsers([{ uid: 1250, email: 'deleted-1256-1250.chaises34@gmail.com' }])
+      queueSelect('employees', [])
+      queueSelect('users', [])
+
+      await repo.restoreEmployee(1256, adminCtx)
+
+      expect(updatesFor('users')[0].values.email).toBe('chaises34@gmail.com')
+    })
+
+    it('still requires admin access', async () => {
+      await expect(
+        repo.restoreEmployee(1256, { employeeId: 2, isAdmin: false, isManager: true })
+      ).rejects.toThrow('Admin access required')
+    })
+  })
+})

--- a/src/lib/repositories/__tests__/EmployeeRepository.rbac.test.ts
+++ b/src/lib/repositories/__tests__/EmployeeRepository.rbac.test.ts
@@ -134,6 +134,8 @@ describe('EmployeeRepository RBAC', () => {
         leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue([]),
         executeTakeFirst: jest.fn().mockResolvedValue({
           id: 1, name: 'Test', email: 'test@test.com', phone_no: null,
           address: '123 St', address_2: null, city: null, state: null,
@@ -215,6 +217,10 @@ describe('EmployeeRepository RBAC', () => {
         leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
+        // getEmployeeById resolves the login account in a second, ordered query
+        // (both linkage conventions live on `users`, not employee_user).
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue([]),
         executeTakeFirst: jest.fn().mockResolvedValue(employeeData),
       }
       ;(db.selectFrom as jest.Mock).mockReturnValue(mockSelect)

--- a/src/lib/repositories/__tests__/EmployeeRepository.search-stats.test.ts
+++ b/src/lib/repositories/__tests__/EmployeeRepository.search-stats.test.ts
@@ -31,7 +31,9 @@ function makeRecordingEb() {
   const subquery: Record<string, unknown> = {}
   subquery.select = jest.fn(() => subquery)
   subquery.innerJoin = jest.fn(() => subquery)
+  subquery.where = jest.fn(() => subquery)
   subquery.whereRef = jest.fn(() => subquery)
+  subquery.orderBy = jest.fn(() => subquery)
   subquery.limit = jest.fn(() => subquery)
   subquery.as = jest.fn(() => ({}))
 
@@ -58,6 +60,8 @@ function makeRecordingEb() {
     return { __exists: x }
   }
   eb.selectFrom = () => subquery
+  // The linked-login relation correlates on employees.id via eb.ref().
+  eb.ref = (col: string) => ({ __ref: col })
   eb.calls = calls
   return eb
 }
@@ -122,21 +126,27 @@ describe('EmployeeRepository.getEmployees — search & join changes', () => {
     expect(cols).toContain('employees.sales_id3')
   })
 
-  it('hasUser: true filters with an EXISTS subquery (no NOT)', async () => {
+  // The hasUser filter is a set operation over the whole table, so it uses
+  // uncorrelated IN-subqueries (employees.id IN users.id / IN employee_user)
+  // rather than a correlated EXISTS — `users.id` has no index, and the
+  // correlated form measured ~400x slower on the production snapshot.
+  it('hasUser: true filters with semi-join IN subqueries (no NOT)', async () => {
     const mockQuery = setupGetEmployeesMock()
     await repo.getEmployees({ hasUser: true }, adminCtx)
 
     const records = collectWhereEbRecords(mockQuery)
-    expect(records.some((r) => r.type === 'exists')).toBe(true)
+    const inCols = records.filter((r) => r.type === 'cmp' && r.args?.[1] === 'in').map((r) => r.col)
+    expect(inCols).toContain('employees.id')
     expect(records.some((r) => r.type === 'not')).toBe(false)
   })
 
-  it('hasUser: false filters with a NOT EXISTS subquery', async () => {
+  it('hasUser: false negates the same semi-join', async () => {
     const mockQuery = setupGetEmployeesMock()
     await repo.getEmployees({ hasUser: false }, adminCtx)
 
     const records = collectWhereEbRecords(mockQuery)
-    expect(records.some((r) => r.type === 'exists')).toBe(true)
+    const inCols = records.filter((r) => r.type === 'cmp' && r.args?.[1] === 'in').map((r) => r.col)
+    expect(inCols).toContain('employees.id')
     expect(records.some((r) => r.type === 'not')).toBe(true)
   })
 

--- a/src/lib/utils/email.ts
+++ b/src/lib/utils/email.ts
@@ -1,0 +1,136 @@
+/**
+ * Email identity helpers shared by the employee repository, the employee API
+ * routes and the admin employee form.
+ *
+ * Kept free of any database/server imports so client components can use the
+ * message/normalisation helpers without pulling the Kysely client into the
+ * browser bundle.
+ */
+
+/** `users.email` / `employees.email` are varchar(255). */
+export const EMAIL_COLUMN_MAX_LENGTH = 255
+
+/**
+ * Canonical form used for comparisons and for NEW values written to the
+ * database. MySQL compares these columns case-insensitively
+ * (utf8mb3_unicode_ci) while JavaScript does not, so every comparison the app
+ * makes must go through here. Existing stored values are never rewritten.
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+/**
+ * Who currently owns an email address.
+ *
+ * - `source: 'employee'` — a live (not soft-deleted) `employees` row.
+ * - `source: 'user'` — a `users` row (the login identity, which carries the
+ *   UNIQUE index). `employeeId`/`employeeName` are resolved through
+ *   `employee_user` when the account is linked to an employee.
+ */
+export interface EmailOwnerInfo {
+  source: 'employee' | 'user'
+  employeeId: number | null
+  employeeName: string | null
+  /** True when the owning employee row is soft-deleted (only possible for `user` matches). */
+  employeeDeleted: boolean
+}
+
+/**
+ * Build the admin-facing conflict message. Never includes the conflicting
+ * email address of another account — names and ids only.
+ */
+export function emailConflictMessage(owner: EmailOwnerInfo | null): string {
+  if (!owner) {
+    return 'Email address is already in use.'
+  }
+
+  const label = owner.employeeName
+    ? `${owner.employeeName} (#${owner.employeeId})`
+    : `#${owner.employeeId}`
+
+  if (owner.source === 'employee') {
+    return `Email address is already in use by employee ${label}.`
+  }
+
+  if (owner.employeeId === null) {
+    return 'Email address is already in use by a login account not linked to any employee.'
+  }
+
+  if (owner.employeeDeleted) {
+    // No "restore that employee to release it" advice: restoring only releases
+    // addresses parked by this app, never a legacy row parked by nothing.
+    return `Email address is already in use by the login account of deleted employee ${label}.`
+  }
+
+  return `Email address is already in use by the login account of employee ${label}.`
+}
+
+/**
+ * Prefix applied to a login email while its employee is soft-deleted, so the
+ * address stops reserving the `users_email_unique` index (and stops working as
+ * a login). The `userUid` form is the collision fallback.
+ */
+export function parkedEmailPrefix(employeeId: number, userUid?: number): string {
+  return userUid === undefined
+    ? `deleted-${employeeId}.`
+    : `deleted-${employeeId}-${userUid}.`
+}
+
+const PARKED_EMAIL_PATTERN = /^deleted-\d+(?:-\d+)?\./
+
+/** True when the value already carries a parking prefix (parking is idempotent). */
+export function isParkedEmail(email: string): boolean {
+  return PARKED_EMAIL_PATTERN.test(email)
+}
+
+/**
+ * Raised when parking an address would overflow the column. Carries a
+ * user-facing message so the delete route can return it as a 400 instead of an
+ * opaque 500.
+ */
+export class ParkedEmailTooLongError extends Error {
+  readonly name = 'ParkedEmailTooLongError'
+
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+/** True for {@link ParkedEmailTooLongError}, without relying on `instanceof`. */
+export function isParkTooLongError(error: unknown): error is ParkedEmailTooLongError {
+  return error instanceof Error && error.name === 'ParkedEmailTooLongError'
+}
+
+/**
+ * Parked value for `email`.
+ *
+ * Never truncates: a truncated prefix would silently corrupt the address that
+ * restore later un-parks. Throws instead, which aborts the delete transaction.
+ */
+export function buildParkedEmail(employeeId: number, email: string, userUid?: number): string {
+  const parked = `${parkedEmailPrefix(employeeId, userUid)}${email}`
+
+  if (parked.length > EMAIL_COLUMN_MAX_LENGTH) {
+    throw new ParkedEmailTooLongError(
+      `Login email too long to park for employee ${employeeId}: the parked value would be ` +
+      `${parked.length} characters (max ${EMAIL_COLUMN_MAX_LENGTH}). ` +
+      'Shorten or clear the login email before deleting this employee.'
+    )
+  }
+
+  return parked
+}
+
+/**
+ * Strip this employee's parking prefix. Returns `null` when the value is not
+ * parked for this employee (leave it alone in that case).
+ */
+export function unparkEmail(email: string, employeeId: number, userUid: number): string | null {
+  for (const prefix of [parkedEmailPrefix(employeeId, userUid), parkedEmailPrefix(employeeId)]) {
+    if (email.startsWith(prefix)) {
+      return email.slice(prefix.length)
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Incident

An admin tried to correct employee #1252's email to an address that appeared unused and got **"Email address is already in use."** The address was held by the login account of a soft-deleted duplicate employee — invisible on every screen, since the admin UI only ever shows `employees.email` and the deleted duplicate's card showed a different address entirely.

## Root causes fixed

1. **Unscoped uniqueness check** — `isEmailAvailable()` matched soft-deleted employees and *every* `users` row, never excluding the edited employee's own login account.
2. **No email sync** — editing `employees.email` never updated the linked `users.email` (the login identity, which carries the real UNIQUE index), so the two drifted permanently. The employee kept logging in with the old address forever.
3. **Delete orphans logins** — soft-deleting an employee left its login account fully live, silently reserving its email forever.
4. **Dead-end errors** — the 400 never said who held the address.
5. **(Found by live smoke test)** the employee↔login relation is **dual** in prod data: the `employee_user` junction (~105 rows) AND the legacy Laravel `users.id = employees.id` convention (~1149 rows; how NextAuth resolves sign-in). All prior link-aware code consulted only the junction, so ~93% of employees were affected: sync no-oped, email edits were irreversible (the old address became "held" by the employee's own unlinked login), and the "With User Accounts" stat read 27 instead of 533.

## Changes

- `isEmailAvailable`/`findEmailOwner`: soft-deleted employees no longer block; the edited employee's own login account(s) are excluded; conflict messages name the owning employee/login (names + ids only, no email leakage), e.g. *"…already in use by the login account of deleted employee Chaise Scott (#1256)."*
- One authoritative definition of the login relation (`isLinkedLoginAccount`): junction OR legacy `users.id` (guarded `> 0`; junction wins if the two ever disagree). A semi-join variant powers the list/stat queries — the correlated form measured **~400× slower** (391ms/548ms vs ~1ms) because `users.id` is unindexed.
- `updateEmployee` syncs `users.email`/`name` in the same transaction, targeting exactly one deterministic account (new-address match → previous-address match → parked-by-this-employee → lowest uid) — multi-account employees exist in prod and a broadcast update would hit the unique index.
- `deleteEmployee` parks linked login emails (`deleted-{employeeId}.{email}`, idempotent, throws typed 400-mapped error rather than truncating) and sets `users.deleted_at`; `restoreEmployee` un-parks when the address is free and warns (now surfaced as a toast) when it isn't.
- Email changes on soft-deleted employees are refused (400 "Restore this employee first") to prevent parked-login drift.
- Employee form: inline availability check on blur (admin-gated endpoint existed but had zero callers), stale-response and stuck-spinner safe; emails normalized (trim+lowercase) on new writes only — legacy mixed-case rows are not rewritten by unrelated edits.
- Detail page/user card and stats now correct for legacy-linked employees; primary login account prefers the address matching `employees.email`.
- CLAUDE.md: documents the dual linkage so future queries don't repeat cause #5.

## Verification

- **102 new unit tests** (repository behavior, route contracts, compile-only SQL assertions that fail if the exclusion predicates or semi-joins regress). Full jest suite: 399 pass; the 2 failures (`AdvanceRepository.resync`, `marketing/products`) are pre-existing on `main` (reproduced on a pristine checkout).
- **Adversarial review** (2 full passes + delta passes): 10 initial findings all fixed and re-verified; dual-link predicate validated against the prod-snapshot DB with **zero disagreements across 1148 employees**; final verdict GO.
- **Browser smoke on prod-snapshot data**: inline + server conflicts show owner-aware messages; save syncs both `employees.email` and `users.email` for a legacy-linked employee; revert works (previously blocked); stat card 533; detail page shows the login account. DB restored to original state afterwards.
- `bun run build` ✓, eslint clean on all touched files, `tsc --noEmit` clean on all touched files.

## Follow-ups (deliberately out of scope)

- Data cleanup: ~78 legacy logins belong to already-deleted employees and still reserve their addresses (never parked because they predate this change). Needs a one-time backfill/park script.
- `searchEmployees` (autocomplete, currently no frontend consumer) still resolves the relation junction-only.
- `create-user` route pre-existing type errors and its bind-by-email path (now guarded downstream by junction-wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)