### PR TITLE
fix: manager payroll visibility + first-class manager pay experience

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -66,11 +66,13 @@ const nextConfig: NextConfig = {
         destination: '/auth/signin',
         permanent: true,
       },
-      {
-        source: '/manager',
-        destination: '/manager/dashboard',
-        permanent: false,
-      },
+      // NOTE: there was a '/manager' -> '/manager/dashboard' redirect here.
+      // Config redirects run in the routing layer before any page code, so it
+      // preempted the auth guards in src/app/manager/page.tsx and made them
+      // dead code. /manager now goes through that page, which checks the
+      // session and forwards managers/admins to /dashboard (unauthenticated ->
+      // /auth/signin, unauthorized -> /forbidden). /manager/dashboard is
+      // unaffected and still reachable directly.
     ]
   },
 };

--- a/src/app/(portal)/dashboard/page.tsx
+++ b/src/app/(portal)/dashboard/page.tsx
@@ -4,9 +4,8 @@ import { PayrollRepository, type PayrollSummary } from '@/lib/repositories/Payro
 import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Wallet, FolderOpen, FileText, Shield, CheckCircle, XCircle, ChevronRight } from 'lucide-react'
-import LatestStatementCard from '@/components/dashboard/LatestStatementCard'
-import RecentStatementsList from '@/components/dashboard/RecentStatementsList'
+import { Wallet, FolderOpen, FileText, Shield, CheckCircle, XCircle, ChevronRight, Users } from 'lucide-react'
+import PersonalPaySection from '@/components/dashboard/PersonalPaySection'
 
 // Build the statement-detail href, returning the rep to the dashboard afterwards.
 const buildStatementHref = (statement: PayrollSummary) =>
@@ -35,9 +34,6 @@ export default async function PortalDashboard() {
       userContext
     )
 
-    const latest = data[0]
-    const recent = data.slice(1, 7)
-
     return (
       <div className="mx-auto max-w-2xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
         <div>
@@ -46,51 +42,7 @@ export default async function PortalDashboard() {
           </h1>
         </div>
 
-        {latest ? (
-          <>
-            <LatestStatementCard statement={latest} href={buildStatementHref(latest)} isPaid={latest.isPaid} />
-
-            {recent.length > 0 && (
-              <section>
-                <div className="mb-3 flex items-center justify-between">
-                  <h2 className="text-lg font-semibold text-foreground">Recent statements</h2>
-                  <Link
-                    href="/payroll"
-                    className="inline-flex min-h-11 items-center text-sm font-medium text-primary hover:underline"
-                  >
-                    View all
-                  </Link>
-                </div>
-                <RecentStatementsList statements={recent} buildHref={buildStatementHref} />
-              </section>
-            )}
-          </>
-        ) : (
-          /* Empty state mirrors PayrollList's copy for reps with no statements. */
-          <div className="rounded-xl border border-border bg-card shadow-sm">
-            <div className="px-4 py-12 text-center">
-              <svg
-                className="mx-auto h-12 w-12 text-muted-foreground"
-                stroke="currentColor"
-                fill="none"
-                viewBox="0 0 48 48"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                />
-              </svg>
-              <h3 className="mt-2 text-sm font-medium text-foreground">No statements yet</h3>
-              <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
-                Your first statement will appear here once payroll is published. Questions? Contact
-                your manager.
-              </p>
-            </div>
-          </div>
-        )}
+        <PersonalPaySection statements={data} buildHref={buildStatementHref} showEmptyState />
 
         {/* Quick link to Documents */}
         <Link
@@ -141,8 +93,23 @@ export default async function PortalDashboard() {
   }
 
   // ---------------------------------------------------------------------------
-  // Admin / Manager home: account overview + quick actions (unchanged).
+  // Admin / Manager home: own pay first, then the team, then admin tooling.
   // ---------------------------------------------------------------------------
+  const elevatedContext = await getEmployeeContext(
+    session.user.employeeId,
+    session.user.isAdmin,
+    session.user.isManager
+  )
+  const hasReports = (elevatedContext.managedEmployeeIds?.length ?? 0) > 0
+
+  // Their OWN statements only. `scope: 'mine'` narrows the role filter to self —
+  // it cannot widen it, and the unreleased-statement cutoff still applies.
+  const elevatedPayrollRepository = new PayrollRepository()
+  const { data: ownStatements } = await elevatedPayrollRepository.getPayrollSummary(
+    { page: 1, limit: 7, scope: 'mine' },
+    elevatedContext
+  )
+
   return (
     <div className="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8">
       <div className="space-y-6 px-4 py-6 sm:px-0">
@@ -153,43 +120,39 @@ export default async function PortalDashboard() {
           </h1>
         </div>
 
-        {/* Account Info */}
-        <Card>
-          <CardContent className="pt-6">
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div>
-                <p className="text-sm text-muted-foreground">Email</p>
-                <p className="text-lg font-medium text-foreground">{session.user.email}</p>
-              </div>
-              <div>
-                <p className="text-sm text-muted-foreground">Employee ID</p>
-                <p className="text-lg font-medium text-foreground">{session.user.employeeId || 'N/A'}</p>
-              </div>
-              <div>
-                <p className="text-sm text-muted-foreground">Role</p>
-                <p className="text-lg font-medium text-foreground">
-                  {session.user.isAdmin ? 'Administrator' : 'Manager'}
-                </p>
-              </div>
-              <div>
-                <p className="text-sm text-muted-foreground">Status</p>
-                <div className="mt-1">
-                  {session.user.isActive ? (
-                    <Badge variant="secondary" className="border-primary/20 bg-primary/10 text-primary">
-                      <CheckCircle className="mr-1 h-3 w-3" />
-                      Active
-                    </Badge>
-                  ) : (
-                    <Badge variant="destructive">
-                      <XCircle className="mr-1 h-3 w-3" />
-                      Inactive
-                    </Badge>
-                  )}
+        {/* Own pay + the way into the team view. Constrained to a readable
+            column so the hero card doesn't stretch across a 7xl page. */}
+        {(ownStatements.length > 0 || hasReports) && (
+          <div className="max-w-2xl space-y-6">
+            <PersonalPaySection
+              statements={ownStatements}
+              buildHref={buildStatementHref}
+              title="Your pay"
+              viewAllHref="/payroll?scope=mine"
+            />
+
+            {hasReports && (
+              <Link
+                href="/payroll?scope=team"
+                className="block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <div className="flex min-h-14 items-center gap-4 rounded-xl border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md active:bg-muted">
+                  <div className="rounded-lg bg-primary/10 p-2.5">
+                    <Users className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-medium text-foreground">Your team&apos;s pay</h3>
+                    <p className="mt-0.5 text-sm text-muted-foreground">
+                      Statements for the {elevatedContext.managedEmployeeIds?.length} employee
+                      {elevatedContext.managedEmployeeIds?.length === 1 ? '' : 's'} you manage
+                    </p>
+                  </div>
+                  <ChevronRight className="h-5 w-5 flex-shrink-0 text-muted-foreground" aria-hidden="true" />
                 </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+              </Link>
+            )}
+          </div>
+        )}
 
         {/* Quick Actions */}
         <div>
@@ -262,6 +225,44 @@ export default async function PortalDashboard() {
             )}
           </div>
         </div>
+
+        {/* Account Info, demoted below pay and quick actions */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-sm text-muted-foreground">Email</p>
+                <p className="text-lg font-medium text-foreground">{session.user.email}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Employee ID</p>
+                <p className="text-lg font-medium text-foreground">{session.user.employeeId || 'N/A'}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Role</p>
+                <p className="text-lg font-medium text-foreground">
+                  {session.user.isAdmin ? 'Administrator' : 'Manager'}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Status</p>
+                <div className="mt-1">
+                  {session.user.isActive ? (
+                    <Badge variant="secondary" className="border-primary/20 bg-primary/10 text-primary">
+                      <CheckCircle className="mr-1 h-3 w-3" />
+                      Active
+                    </Badge>
+                  ) : (
+                    <Badge variant="destructive">
+                      <XCircle className="mr-1 h-3 w-3" />
+                      Inactive
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/(portal)/payroll/page.tsx
+++ b/src/app/(portal)/payroll/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth } from '@/lib/auth/server-auth'
-import { PayrollRepository } from '@/lib/repositories/PayrollRepository'
+import { PayrollRepository, parsePayrollScope } from '@/lib/repositories/PayrollRepository'
 import { getEmployeeContext, getPayrollAccessSummary } from '@/lib/auth/payroll-access'
 import PayrollList from '@/components/payroll/PayrollList'
 import PayrollFilters from '@/components/payroll/PayrollFilters'
@@ -13,6 +13,7 @@ interface PageProps {
     startDate?: string
     endDate?: string
     status?: 'paid' | 'unpaid' | 'all'
+    scope?: string
     page?: string
     limit?: string
   }>
@@ -30,7 +31,11 @@ export default async function PayrollPage({ searchParams }: PageProps) {
     session.user.isAdmin,
     session.user.isManager
   )
-  // Build filters from search params
+  // Only offer the "My team" scope to viewers who actually have direct reports.
+  const hasReports = (userContext.managedEmployeeIds?.length ?? 0) > 0
+
+  // Build filters from search params. `scope` is validated against the literal
+  // union before it reaches the repository — never forward a raw query string.
   const filters = {
     employeeId: resolvedSearchParams.employeeId ? parseInt(resolvedSearchParams.employeeId) : undefined,
     vendorId: resolvedSearchParams.vendorId ? parseInt(resolvedSearchParams.vendorId) : undefined,
@@ -38,6 +43,7 @@ export default async function PayrollPage({ searchParams }: PageProps) {
     startDate: resolvedSearchParams.startDate,
     endDate: resolvedSearchParams.endDate,
     status: resolvedSearchParams.status || 'all',
+    scope: parsePayrollScope(resolvedSearchParams.scope),
     page: resolvedSearchParams.page ? parseInt(resolvedSearchParams.page) : 1,
     limit: resolvedSearchParams.limit ? parseInt(resolvedSearchParams.limit) : 20
   }
@@ -59,11 +65,14 @@ export default async function PayrollPage({ searchParams }: PageProps) {
           </h1>
           <p className="mt-2 max-w-4xl text-sm text-muted-foreground">
             View and manage payroll information for agents and vendors.
-            {!session.user.isAdmin && (
-              <span className="block mt-1">
-                Access limited to your {session.user.isManager ? 'managed employees and' : ''} data.
-              </span>
-            )}
+            {/* All three access cases, stated accurately. */}
+            <span className="block mt-1">
+              {session.user.isAdmin
+                ? 'Full access to every agent and vendor across the organization.'
+                : session.user.isManager && hasReports
+                  ? 'Access limited to your own pay and the employees you manage.'
+                  : 'Access limited to your own pay data.'}
+            </span>
           </p>
         </div>
       </div>
@@ -129,6 +138,7 @@ export default async function PayrollPage({ searchParams }: PageProps) {
           <PayrollFilters
             initialFilters={filters}
             userContext={{ isAdmin: session.user.isAdmin, isManager: session.user.isManager }}
+            hasReports={hasReports}
           />
         </Suspense>
       </div>

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -32,12 +32,14 @@ export default function SignIn() {
       if (result?.error) {
         setError('Email or password is incorrect')
       } else {
-        // Get the session to check user role and redirect appropriately
+        // Get the session to check user role and redirect appropriately.
+        // Managers land on /dashboard alongside reps: that is where their own
+        // pay lives, plus the way into their team's. (/manager is an orphaned
+        // stub that now just redirects there.) Admins keep their own landing;
+        // an admin who is also a manager still takes the admin branch first.
         const session = await getSession()
         if (session?.user.isAdmin) {
           router.push('/admin')
-        } else if (session?.user.isManager) {
-          router.push('/manager')
         } else {
           router.push('/dashboard')
         }

--- a/src/app/manager/__tests__/page.test.ts
+++ b/src/app/manager/__tests__/page.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `/manager` is an orphaned stub that now redirects to /dashboard. It is only
+ * reachable by bookmark, so the guards that stop it becoming an open redirect
+ * for unauthenticated / unauthorized visitors are worth pinning down.
+ *
+ * The page is a plain async server component (session lookup + redirect, no
+ * rendering), so this needs no React test harness.
+ */
+
+/** Emulates the real `redirect()`, which throws to halt execution. */
+class RedirectError extends Error {
+  constructor(public readonly target: string) {
+    super(`NEXT_REDIRECT:${target}`)
+  }
+}
+
+const mockGetServerSession = jest.fn()
+const mockRedirect = jest.fn((target: string) => {
+  throw new RedirectError(target)
+})
+
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}))
+
+jest.mock('@/lib/auth/config', () => ({
+  authOptions: {},
+}))
+
+jest.mock('next/navigation', () => ({
+  redirect: (target: string) => mockRedirect(target),
+}))
+
+import ManagerPage from '../page'
+
+/** Runs the page and returns the single redirect target it attempted. */
+async function redirectTarget(): Promise<string> {
+  try {
+    await ManagerPage()
+  } catch (error) {
+    if (error instanceof RedirectError) return error.target
+    throw error
+  }
+  throw new Error('ManagerPage returned without redirecting')
+}
+
+describe('/manager redirects to /dashboard behind its auth guards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('sends a manager to /dashboard, where their own pay now lives', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { isAdmin: false, isManager: true },
+    })
+
+    expect(await redirectTarget()).toBe('/dashboard')
+    expect(mockRedirect).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends an admin to /dashboard too', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { isAdmin: true, isManager: false },
+    })
+
+    expect(await redirectTarget()).toBe('/dashboard')
+  })
+
+  it('sends an unauthenticated visitor to /auth/signin, never to /dashboard', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    expect(await redirectTarget()).toBe('/auth/signin')
+    // The guard must short-circuit — no second, unauthorized redirect.
+    expect(mockRedirect).toHaveBeenCalledTimes(1)
+    expect(mockRedirect).not.toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('sends a session with no user to /auth/signin', async () => {
+    mockGetServerSession.mockResolvedValue({})
+
+    expect(await redirectTarget()).toBe('/auth/signin')
+  })
+
+  it('sends a plain employee to /forbidden, never to /dashboard', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { isAdmin: false, isManager: false },
+    })
+
+    expect(await redirectTarget()).toBe('/forbidden')
+    expect(mockRedirect).toHaveBeenCalledTimes(1)
+    expect(mockRedirect).not.toHaveBeenCalledWith('/dashboard')
+  })
+})

--- a/src/app/manager/dashboard/page.tsx
+++ b/src/app/manager/dashboard/page.tsx
@@ -1,149 +1,24 @@
 import { requireAuth } from '@/lib/auth/utils'
 import { redirect } from 'next/navigation'
-import ProtectedLayout from '@/components/layout/ProtectedLayout'
 
+/**
+ * `/manager/dashboard` was the page managers actually landed on after sign-in,
+ * via a `/manager` → `/manager/dashboard` rewrite in next.config.ts. It was a
+ * stub whose links pointed at /manager/team, /manager/approvals, /manager/jobs,
+ * /manager/payroll, /manager/reports and /manager/schedule — none of which
+ * exist. Managers now land on /dashboard, where their own pay and the route
+ * into their team's pay live.
+ *
+ * Kept (rather than deleted) so existing bookmarks land somewhere useful, and
+ * it keeps its auth guards so it never becomes an open redirect. Mirrors
+ * `/manager`, which redirects the same way.
+ */
 export default async function ManagerDashboard() {
   const session = await requireAuth()
-  
-  // Ensure user is manager or admin
+
   if (!session.user.isManager && !session.user.isAdmin) {
-    redirect('/dashboard')
+    redirect('/forbidden')
   }
 
-  return (
-    <ProtectedLayout>
-      <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        {/* Header */}
-        <div className="px-4 py-6 sm:px-0">
-          <div className="bg-card shadow rounded-lg p-8">
-            <h1 className="text-3xl font-bold text-foreground mb-4">
-              Manager Dashboard
-            </h1>
-            <p className="text-lg text-muted-foreground mb-6">
-              Welcome back, {session.user.name}. Manage your team.
-            </p>
-            
-            {/* Manager Stats Cards */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-              <div className="bg-card overflow-hidden shadow rounded-lg">
-                <div className="p-5">
-                  <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <div className="w-8 h-8 bg-primary rounded-md flex items-center justify-center">
-                        <span className="text-white text-sm font-medium">👥</span>
-                      </div>
-                    </div>
-                    <div className="ml-5 w-0 flex-1">
-                      <dl>
-                        <dt className="text-sm font-medium text-muted-foreground truncate">Team Members</dt>
-                        <dd className="text-lg font-medium text-foreground">--</dd>
-                      </dl>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="bg-card overflow-hidden shadow rounded-lg">
-                <div className="p-5">
-                  <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <div className="w-8 h-8 bg-primary rounded-md flex items-center justify-center">
-                        <span className="text-white text-sm font-medium">✅</span>
-                      </div>
-                    </div>
-                    <div className="ml-5 w-0 flex-1">
-                      <dl>
-                        <dt className="text-sm font-medium text-muted-foreground truncate">Approvals Pending</dt>
-                        <dd className="text-lg font-medium text-foreground">--</dd>
-                      </dl>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="bg-card overflow-hidden shadow rounded-lg">
-                <div className="p-5">
-                  <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <div className="w-8 h-8 bg-secondary rounded-md flex items-center justify-center">
-                        <span className="text-white text-sm font-medium">📋</span>
-                      </div>
-                    </div>
-                    <div className="ml-5 w-0 flex-1">
-                      <dl>
-                        <dt className="text-sm font-medium text-muted-foreground truncate">Active Jobs</dt>
-                        <dd className="text-lg font-medium text-foreground">--</dd>
-                      </dl>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Manager Actions */}
-            <div className="bg-card shadow rounded-lg p-6">
-              <h2 className="text-xl font-semibold text-foreground mb-4">Manager Actions</h2>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <a 
-                  href="/manager/team" 
-                  className="block p-4 border border-border rounded-lg hover:bg-muted transition-colors"
-                >
-                  <h3 className="font-medium text-foreground">Team Management</h3>
-                  <p className="text-sm text-muted-foreground">View and manage your team members</p>
-                </a>
-                
-                <a 
-                  href="/manager/approvals" 
-                  className="block p-4 border border-border rounded-lg hover:bg-muted transition-colors"
-                >
-                  <h3 className="font-medium text-foreground">Pending Approvals</h3>
-                  <p className="text-sm text-muted-foreground">Review and approve team requests</p>
-                </a>
-                
-                <a 
-                  href="/manager/jobs" 
-                  className="block p-4 border border-border rounded-lg hover:bg-muted transition-colors"
-                >
-                  <h3 className="font-medium text-foreground">Job Management</h3>
-                  <p className="text-sm text-muted-foreground">Create and manage job assignments</p>
-                </a>
-                
-                <a 
-                  href="/manager/payroll" 
-                  className="block p-4 border border-border rounded-lg hover:bg-muted transition-colors"
-                >
-                  <h3 className="font-medium text-foreground">Payroll Review</h3>
-                  <p className="text-sm text-muted-foreground">Review team payroll information</p>
-                </a>
-                
-                <a 
-                  href="/admin/invoice-search" 
-                  className="block p-4 border border-border rounded-lg hover:bg-muted transition-colors"
-                >
-                  <h3 className="font-medium text-foreground">Invoice Investigation</h3>
-                  <p className="text-sm text-muted-foreground">Search and investigate invoice audit trails</p>
-                </a>
-                
-                <a 
-                  href="/manager/reports" 
-                  className="block p-4 border border-border rounded-lg hover:bg-muted transition-colors"
-                >
-                  <h3 className="font-medium text-foreground">Team Reports</h3>
-                  <p className="text-sm text-muted-foreground">Generate team performance reports</p>
-                </a>
-                
-                <a 
-                  href="/manager/schedule" 
-                  className="block p-4 border border-border rounded-lg hover:bg-muted transition-colors"
-                >
-                  <h3 className="font-medium text-foreground">Scheduling</h3>
-                  <p className="text-sm text-muted-foreground">Manage team schedules and assignments</p>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </ProtectedLayout>
-  )
+  redirect('/dashboard')
 }

--- a/src/app/manager/page.tsx
+++ b/src/app/manager/page.tsx
@@ -2,91 +2,27 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
 import { redirect } from 'next/navigation'
 
+/**
+ * `/manager` is an orphaned stub: nothing in the app's navigation links to it,
+ * and its three primary cards pointed at /manager/employees, /manager/payroll
+ * and /manager/reports, none of which exist. It was only ever reachable via the
+ * post-sign-in redirect, which now sends managers to /dashboard — where their
+ * own pay and the route into their team's pay live.
+ *
+ * The route is kept (rather than deleted) so existing bookmarks land somewhere
+ * useful, and it keeps its auth guards so it never becomes an open redirect for
+ * unauthenticated or unauthorized visitors.
+ */
 export default async function ManagerPage() {
   const session = await getServerSession(authOptions)
-  
+
   if (!session?.user) {
     redirect('/auth/signin')
   }
-  
+
   if (!session.user.isAdmin && !session.user.isManager) {
     redirect('/forbidden')
   }
 
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="max-w-4xl mx-auto">
-        <div className="bg-card rounded-lg shadow-sm border p-6">
-          <div className="flex items-center justify-between mb-6">
-            <div>
-              <h1 className="text-2xl font-bold text-foreground">Manager Dashboard</h1>
-              <p className="text-muted-foreground mt-1">Welcome back, {session.user.name}</p>
-            </div>
-            <div className="text-sm text-muted-foreground">
-              Role: {session.user.isAdmin ? 'Administrator' : 'Manager'}
-            </div>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <div className="bg-primary/10 p-6 rounded-lg border border-primary/20">
-              <h3 className="font-semibold text-primary mb-2">Team Management</h3>
-              <p className="text-primary text-sm mb-4">Manage your team members and their access.</p>
-              <a
-                href="/manager/employees"
-                className="inline-flex items-center text-primary hover:text-primary/80 text-sm font-medium"
-              >
-                View Team →
-              </a>
-            </div>
-
-            <div className="bg-primary/10 p-6 rounded-lg border border-primary/20">
-              <h3 className="font-semibold text-primary mb-2">Payroll Review</h3>
-              <p className="text-primary text-sm mb-4">Review and approve payroll submissions.</p>
-              <a
-                href="/manager/payroll"
-                className="inline-flex items-center text-primary hover:text-primary/80 text-sm font-medium"
-              >
-                Review Payroll →
-              </a>
-            </div>
-
-            <div className="bg-muted p-6 rounded-lg border border-border">
-              <h3 className="font-semibold text-foreground mb-2">Reports</h3>
-              <p className="text-muted-foreground text-sm mb-4">Generate and view performance reports.</p>
-              <a
-                href="/manager/reports"
-                className="inline-flex items-center text-primary hover:text-primary/80 text-sm font-medium"
-              >
-                View Reports →
-              </a>
-            </div>
-          </div>
-          
-          <div className="mt-8 pt-6 border-t border-border">
-            <h2 className="text-lg font-semibold text-foreground mb-4">Quick Actions</h2>
-            <div className="flex flex-wrap gap-3">
-              <a 
-                href="/manager/dashboard"
-                className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary/90 text-sm font-medium"
-              >
-                Dashboard Overview
-              </a>
-              <a 
-                href="/invoices"
-                className="px-4 py-2 bg-muted-foreground text-white rounded-md hover:bg-foreground text-sm font-medium"
-              >
-                View Invoices
-              </a>
-              <a 
-                href="/documents"
-                className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary/90 text-sm font-medium"
-              >
-                Documents
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
+  redirect('/dashboard')
 }

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -26,12 +26,14 @@ export default function SignInForm() {
       if (result?.error) {
         setError('Invalid email or password')
       } else {
-        // Get the session to check user role and redirect appropriately
+        // Get the session to check user role and redirect appropriately.
+        // Managers land on /dashboard alongside reps: that is where their own
+        // pay lives, plus the way into their team's. (/manager is an orphaned
+        // stub that now just redirects there.) Admins keep their own landing;
+        // an admin who is also a manager still takes the admin branch first.
         const session = await getSession()
         if (session?.user.isAdmin) {
           router.push('/admin')
-        } else if (session?.user.isManager) {
-          router.push('/manager')
         } else {
           router.push('/dashboard')
         }

--- a/src/components/dashboard/PersonalPaySection.tsx
+++ b/src/components/dashboard/PersonalPaySection.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link'
+import { PayrollSummary } from '@/lib/repositories/PayrollRepository'
+import LatestStatementCard from '@/components/dashboard/LatestStatementCard'
+import RecentStatementsList from '@/components/dashboard/RecentStatementsList'
+
+interface PersonalPaySectionProps {
+  /** The viewer's OWN statements, newest first (fetch with `scope: 'mine'`). */
+  statements: PayrollSummary[]
+  /** Builds the statement-detail href for a given row. */
+  buildHref: (statement: PayrollSummary) => string
+  /**
+   * Heading rendered above the hero. Omitted on the rep home, where the pay
+   * block IS the page and needs no label — keeping that layout unchanged.
+   */
+  title?: string
+  /** Where "View all" points. Defaults to the unscoped payroll list. */
+  viewAllHref?: string
+  /**
+   * Render the "No statements yet" card when the viewer has none. Reps only —
+   * an elevated user with no statements of their own renders nothing at all,
+   * rather than an empty hero on a page that is not about their pay.
+   */
+  showEmptyState?: boolean
+}
+
+/**
+ * The viewer's own pay: hero card for the latest statement plus a compact list
+ * of the ones before it. Shared by the rep home and the manager/admin home so
+ * both render the same thing from the same markup.
+ */
+export default function PersonalPaySection({
+  statements,
+  buildHref,
+  title,
+  viewAllHref = '/payroll',
+  showEmptyState = false,
+}: PersonalPaySectionProps) {
+  const latest = statements[0]
+  const recent = statements.slice(1, 7)
+
+  if (!latest) {
+    if (!showEmptyState) return null
+
+    return (
+      /* Empty state mirrors PayrollList's copy for reps with no statements. */
+      <div className="rounded-xl border border-border bg-card shadow-sm">
+        <div className="px-4 py-12 text-center">
+          <svg
+            className="mx-auto h-12 w-12 text-muted-foreground"
+            stroke="currentColor"
+            fill="none"
+            viewBox="0 0 48 48"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-foreground">No statements yet</h3>
+          <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
+            Your first statement will appear here once payroll is published. Questions? Contact
+            your manager.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const body = (
+    <>
+      <LatestStatementCard statement={latest} href={buildHref(latest)} isPaid={latest.isPaid} />
+
+      {recent.length > 0 && (
+        <section>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-foreground">Recent statements</h2>
+            <Link
+              href={viewAllHref}
+              className="inline-flex min-h-11 items-center text-sm font-medium text-primary hover:underline"
+            >
+              View all
+            </Link>
+          </div>
+          <RecentStatementsList statements={recent} buildHref={buildHref} />
+        </section>
+      )}
+    </>
+  )
+
+  // Untitled (rep home): emit the blocks as bare siblings so the parent's
+  // `space-y-6` rhythm is preserved exactly as before this was extracted.
+  if (!title) return body
+
+  return (
+    <section aria-labelledby="personal-pay-heading" className="space-y-4">
+      <h2 id="personal-pay-heading" className="text-xl font-semibold text-foreground">
+        {title}
+      </h2>
+      {body}
+    </section>
+  )
+}

--- a/src/components/payroll/PayrollFilters.tsx
+++ b/src/components/payroll/PayrollFilters.tsx
@@ -18,16 +18,39 @@ interface PayrollFiltersProps {
     startDate?: string
     endDate?: string
     status?: string
+    scope?: string
   }
   userContext?: {
     isAdmin: boolean
     isManager: boolean
   }
+  /**
+   * Whether the viewer has direct reports. Resolved server-side from
+   * `managedEmployeeIds` — without reports "My team" is a dead option, so that
+   * one choice is dropped from the toggle.
+   */
+  hasReports?: boolean
 }
 
-export default function PayrollFilters({ initialFilters, userContext }: PayrollFiltersProps) {
+export default function PayrollFilters({ initialFilters, userContext, hasReports }: PayrollFiltersProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
+
+  // Derived from the URL rather than local state so it stays correct after
+  // back/forward navigation and any other filter push.
+  const scopeParam = searchParams.get('scope')
+  const activeScope = scopeParam === 'mine' || scopeParam === 'team' ? scopeParam : 'all'
+
+  // Shown to every elevated viewer, not just those with reports: the dashboard
+  // links admins and report-less managers to ?scope=mine, and without the
+  // toggle that would be a silent, unescapable filter. "My team" is the only
+  // option that needs reports to be meaningful.
+  const isElevated = Boolean(userContext?.isAdmin || userContext?.isManager)
+  const scopeOptions = [
+    { value: 'all', label: 'All' },
+    { value: 'mine', label: 'My pay' },
+    ...(hasReports ? [{ value: 'team', label: 'My team' }] : []),
+  ]
 
   const [filters, setFilters] = useState(initialFilters)
   const [quickFilter, setQuickFilter] = useState<string>('all')
@@ -138,6 +161,22 @@ export default function PayrollFilters({ initialFilters, userContext }: PayrollF
     router.push(`/payroll?${params.toString()}`)
   }
 
+  const handleScopeChange = (scope: string) => {
+    const params = new URLSearchParams(searchParams)
+
+    if (scope === 'mine' || scope === 'team') {
+      params.set('scope', scope)
+    } else {
+      params.delete('scope')
+    }
+
+    // The row count changes with the scope, so an old page number can land the
+    // viewer past the end of the narrowed list.
+    params.delete('page')
+
+    router.push(`/payroll?${params.toString()}`)
+  }
+
   const clearFilters = () => {
     setFilters({})
     router.push('/payroll')
@@ -192,7 +231,10 @@ export default function PayrollFilters({ initialFilters, userContext }: PayrollF
       filters.startDate,
       filters.endDate,
     ].filter(Boolean).length +
-    (filters.status && filters.status !== 'all' ? 1 : 0)
+    (filters.status && filters.status !== 'all' ? 1 : 0) +
+    // Counted whenever the toggle is rendered, so an active scope is never
+    // invisible to a viewer who has the control to clear it.
+    (isElevated && activeScope !== 'all' ? 1 : 0)
 
   if (loading) {
     return (
@@ -215,7 +257,44 @@ export default function PayrollFilters({ initialFilters, userContext }: PayrollF
         <h3 className="text-lg leading-6 font-medium text-foreground mb-4">
           Filter Payroll Data
         </h3>
-        
+
+        {/* Own-vs-team scope toggle (elevated viewers only) */}
+        {isElevated && (
+          <div className="mb-4">
+            {/* Not a <label>: it names a radio-style group, not a form control. */}
+            <span
+              id="payroll-scope-label"
+              className="text-sm font-medium text-foreground mb-2 block"
+            >
+              Show
+            </span>
+            <div
+              role="group"
+              aria-labelledby="payroll-scope-label"
+              className="inline-flex flex-wrap gap-1 rounded-lg border border-border bg-muted p-1"
+            >
+              {scopeOptions.map((option) => {
+                const isActive = activeScope === option.value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={isActive}
+                    onClick={() => handleScopeChange(option.value)}
+                    className={`min-h-11 rounded-md px-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+                      isActive
+                        ? 'bg-card text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
         {/* Employee-only Quick Filters */}
         {!userContext?.isAdmin && !userContext?.isManager ? (
           <div className="space-y-4">

--- a/src/lib/auth/__tests__/payroll-access.test.ts
+++ b/src/lib/auth/__tests__/payroll-access.test.ts
@@ -1,0 +1,103 @@
+import type { UserContext } from '@/lib/auth/types'
+
+type MockChain = Record<string, jest.Mock>
+
+// eslint-disable-next-line no-var
+var mockChain: MockChain
+
+jest.mock('@/lib/database/client', () => {
+  mockChain = {
+    selectFrom: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue([]),
+    executeTakeFirst: jest.fn().mockResolvedValue(null),
+  }
+  return { db: mockChain }
+})
+
+// getAccessibleIssueDates delegates to the repository; stub it out so this file
+// only exercises the access-filter logic in payroll-access itself.
+jest.mock('@/lib/repositories/PayrollRepository', () => ({
+  PayrollRepository: jest.fn().mockImplementation(() => ({
+    getAvailableIssueDates: jest.fn().mockResolvedValue([]),
+  })),
+}))
+
+import { getAccessibleAgents } from '@/lib/auth/payroll-access'
+
+const SELF = 36
+const SUBORDINATE = 1184
+
+const adminCtx: UserContext = { employeeId: 1, isAdmin: true, isManager: false }
+const managerCtx: UserContext = {
+  employeeId: SELF,
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [SUBORDINATE],
+}
+const managerNoReportsCtx: UserContext = {
+  employeeId: SELF,
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [],
+}
+const employeeCtx: UserContext = { employeeId: 7, isAdmin: false, isManager: false }
+const orphanManagerCtx: UserContext = { isAdmin: false, isManager: true }
+
+/** Role-filter predicates on the employees primary key (not sales_id1/is_active). */
+function idFilters() {
+  return mockChain.where.mock.calls.filter((call: unknown[]) => call[0] === 'id')
+}
+
+describe('getAccessibleAgents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockChain.execute.mockResolvedValue([])
+  })
+
+  it('includes the manager themselves alongside their subordinates', async () => {
+    await getAccessibleAgents(managerCtx)
+
+    expect(idFilters()).toEqual([['id', 'in', [SELF, SUBORDINATE]]])
+  })
+
+  it('scopes a manager with zero subordinates to self only', async () => {
+    await getAccessibleAgents(managerNoReportsCtx)
+
+    expect(idFilters()).toEqual([['id', 'in', [SELF]]])
+  })
+
+  it('dedupes when managedEmployeeIds already contains the manager', async () => {
+    await getAccessibleAgents({ ...managerCtx, managedEmployeeIds: [SELF, SUBORDINATE] })
+
+    expect(idFilters()).toEqual([['id', 'in', [SELF, SUBORDINATE]]])
+  })
+
+  it('keeps the sales_id1 and is_active guards in place for managers', async () => {
+    await getAccessibleAgents(managerCtx)
+
+    expect(mockChain.where).toHaveBeenCalledWith('sales_id1', '!=', '')
+    expect(mockChain.where).toHaveBeenCalledWith('is_active', '=', 1)
+  })
+
+  it('applies no employee filter for admins', async () => {
+    await getAccessibleAgents(adminCtx)
+
+    expect(idFilters()).toHaveLength(0)
+  })
+
+  it('still scopes a plain employee to an equality match on self', async () => {
+    await getAccessibleAgents(employeeCtx)
+
+    expect(idFilters()).toEqual([['id', '=', 7]])
+  })
+
+  it('returns an empty list for a manager with neither employeeId nor subordinates', async () => {
+    const result = await getAccessibleAgents(orphanManagerCtx)
+
+    expect(result).toEqual([])
+    expect(idFilters()).toHaveLength(0)
+  })
+})

--- a/src/lib/auth/__tests__/types.test.ts
+++ b/src/lib/auth/__tests__/types.test.ts
@@ -1,5 +1,5 @@
 import type { UserContext } from '@/lib/auth/types'
-import { buildUserContext } from '@/lib/auth/types'
+import { accessibleEmployeeIds, buildUserContext } from '@/lib/auth/types'
 
 describe('UserContext', () => {
   describe('buildUserContext', () => {
@@ -43,6 +43,36 @@ describe('UserContext', () => {
         isManager: false,
       })
       expect(ctx.employeeId).toBeUndefined()
+    })
+  })
+
+  describe('accessibleEmployeeIds', () => {
+    it('puts self first, followed by managed employees', () => {
+      expect(
+        accessibleEmployeeIds({ employeeId: 36, managedEmployeeIds: [1184] })
+      ).toEqual([36, 1184])
+    })
+
+    it('returns self only when the manager has no subordinates', () => {
+      expect(accessibleEmployeeIds({ employeeId: 36, managedEmployeeIds: [] })).toEqual([36])
+    })
+
+    it('returns self only when managedEmployeeIds is undefined', () => {
+      expect(accessibleEmployeeIds({ employeeId: 36 })).toEqual([36])
+    })
+
+    it('dedupes when managedEmployeeIds already contains self', () => {
+      expect(
+        accessibleEmployeeIds({ employeeId: 36, managedEmployeeIds: [36, 1184, 1184] })
+      ).toEqual([36, 1184])
+    })
+
+    it('returns an empty array when there is no employeeId and nothing managed', () => {
+      expect(accessibleEmployeeIds({})).toEqual([])
+    })
+
+    it('falls back to managed ids when employeeId is missing', () => {
+      expect(accessibleEmployeeIds({ managedEmployeeIds: [10, 11] })).toEqual([10, 11])
     })
   })
 })

--- a/src/lib/auth/payroll-access.ts
+++ b/src/lib/auth/payroll-access.ts
@@ -1,6 +1,6 @@
 import { PayrollRepository } from '@/lib/repositories/PayrollRepository'
 import { db } from '@/lib/database/client'
-import type { UserContext } from '@/lib/auth/types'
+import { accessibleEmployeeIds, type UserContext } from '@/lib/auth/types'
 
 /**
  * Role-aware data access helpers for payroll functionality
@@ -106,8 +106,11 @@ export async function getAccessibleAgents(
 
   // Apply role-based filtering
   if (!userContext.isAdmin) {
-    if (userContext.isManager && userContext.managedEmployeeIds?.length) {
-      query = query.where('id', 'in', userContext.managedEmployeeIds)
+    // Managers see themselves AND their subordinates
+    const accessibleIds = accessibleEmployeeIds(userContext)
+
+    if (userContext.isManager && accessibleIds.length) {
+      query = query.where('id', 'in', accessibleIds)
     } else if (userContext.employeeId) {
       query = query.where('id', '=', userContext.employeeId)
     } else {

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -35,3 +35,36 @@ export function buildUserContext(input: {
     managedEmployeeIds: input.managedEmployeeIds,
   }
 }
+
+/**
+ * Employee IDs a non-admin user may READ list-level data for: their own
+ * employee record plus every employee they manage.
+ *
+ * `managedEmployeeIds` comes from `manager_employees`, which never contains the
+ * manager themselves, so self must be added explicitly — otherwise a manager
+ * with at least one subordinate silently loses visibility of their own records.
+ * Deduped defensively in case a self-referential `manager_employees` row exists.
+ *
+ * Returns an empty array when there is no employeeId and nothing managed; the
+ * caller decides what "no accessible ids" means for its query.
+ *
+ * NOTE: read scope only. Write-permission checks (invoices, advances, scheduled
+ * expenses) deliberately exclude self and must keep using `managedEmployeeIds`.
+ */
+export function accessibleEmployeeIds(
+  userContext: Pick<UserContext, 'employeeId' | 'managedEmployeeIds'>
+): number[] {
+  const ids: number[] = []
+
+  if (userContext.employeeId) {
+    ids.push(userContext.employeeId)
+  }
+
+  for (const id of userContext.managedEmployeeIds ?? []) {
+    if (!ids.includes(id)) {
+      ids.push(id)
+    }
+  }
+
+  return ids
+}

--- a/src/lib/repositories/InvoiceRepository.simple.ts
+++ b/src/lib/repositories/InvoiceRepository.simple.ts
@@ -641,20 +641,35 @@ export class InvoiceRepository {
     logger.log('📊 Getting invoice page resources')
 
     try {
-      // Get active agents with all sales IDs for filtering
-      let agentQuery = db
-        .selectFrom('employees')
-        .select(['id', 'name', 'sales_id1', 'sales_id2', 'sales_id3'])
-        .where('is_active', '=', 1)
-        .where('deleted_at', 'is', null)
+      // Get active agents with all sales IDs for filtering.
+      // Fail closed: a non-admin manager's agent list is exactly their direct
+      // reports. With zero direct reports the list must be empty — never fall
+      // through to an unfiltered query over every active employee. The query is
+      // skipped entirely in that case (an `IN ()` predicate is invalid MySQL).
+      const managedEmployeeIds = userContext.managedEmployeeIds ?? []
+      let agents: Array<{
+        id: number
+        name: string
+        sales_id1: string
+        sales_id2: string
+        sales_id3: string
+      }> = []
 
-      if (!userContext.isAdmin && userContext.isManager && userContext.managedEmployeeIds?.length) {
-        agentQuery = agentQuery.where('id', 'in', userContext.managedEmployeeIds)
+      if (userContext.isAdmin || managedEmployeeIds.length > 0) {
+        let agentQuery = db
+          .selectFrom('employees')
+          .select(['id', 'name', 'sales_id1', 'sales_id2', 'sales_id3'])
+          .where('is_active', '=', 1)
+          .where('deleted_at', 'is', null)
+
+        if (!userContext.isAdmin) {
+          agentQuery = agentQuery.where('id', 'in', managedEmployeeIds)
+        }
+
+        agents = await agentQuery
+          .orderBy('name')
+          .execute()
       }
-
-      const agents = await agentQuery
-        .orderBy('name')
-        .execute()
 
       // Get active vendors
       const vendors = await db

--- a/src/lib/repositories/InvoiceRepository.ts
+++ b/src/lib/repositories/InvoiceRepository.ts
@@ -177,20 +177,29 @@ export class InvoiceRepository {
       throw new Error('Insufficient permissions')
     }
 
-    // Get active employees
-    let agentQuery = db
-      .selectFrom('employees')
-      .select(['id', 'name', 'sales_id1'])
-      .where('is_active', '=', 1)
-      .where('hidden_payroll', '=', 0)
+    // Get active employees.
+    // Fail closed: a non-admin manager's agent list is exactly their direct
+    // reports. With zero direct reports the list must be empty — never fall
+    // through to an unfiltered query over every active employee. The query is
+    // skipped entirely in that case (an `IN ()` predicate is invalid MySQL).
+    const managedEmployeeIds = userContext.managedEmployeeIds ?? []
+    let agents: Array<{ id: number; name: string; sales_id1: string }> = []
 
-    if (!userContext.isAdmin && userContext.isManager && userContext.managedEmployeeIds?.length) {
-      agentQuery = agentQuery.where('id', 'in', userContext.managedEmployeeIds)
+    if (userContext.isAdmin || managedEmployeeIds.length > 0) {
+      let agentQuery = db
+        .selectFrom('employees')
+        .select(['id', 'name', 'sales_id1'])
+        .where('is_active', '=', 1)
+        .where('hidden_payroll', '=', 0)
+
+      if (!userContext.isAdmin) {
+        agentQuery = agentQuery.where('id', 'in', managedEmployeeIds)
+      }
+
+      agents = await agentQuery
+        .orderBy('name', 'asc')
+        .execute()
     }
-
-    const agents = await agentQuery
-      .orderBy('name', 'asc')
-      .execute()
 
     // Get active vendors
     const vendors = await db

--- a/src/lib/repositories/PayrollRepository.ts
+++ b/src/lib/repositories/PayrollRepository.ts
@@ -12,6 +12,42 @@ import {
 } from '@/lib/utils/payroll-visibility'
 
 
+/**
+ * Optional narrowing of a payroll list to one side of an elevated user's access:
+ * `mine` = only their own statements, `team` = only the people they manage.
+ *
+ * SECURITY: a scope may only ever REMOVE rows from what the role filter already
+ * allows. It is intersected with the role-resolved id set, never substituted for
+ * it. See `resolveEmployeeScope`.
+ */
+export type PayrollScope = 'mine' | 'team'
+
+const PAYROLL_SCOPES: readonly PayrollScope[] = ['mine', 'team']
+
+/**
+ * Validate an untrusted value (e.g. a `searchParams` string) against the
+ * `PayrollScope` union. Anything else — including garbage, arrays and empty
+ * strings — resolves to `undefined`, i.e. "no narrowing", which is the safe
+ * default. Never pass an unvalidated string into `PayrollFilters.scope`.
+ */
+export function parsePayrollScope(value: unknown): PayrollScope | undefined {
+  return typeof value === 'string' && (PAYROLL_SCOPES as readonly string[]).includes(value)
+    ? (value as PayrollScope)
+    : undefined
+}
+
+/**
+ * How the employees.id predicate should be applied for a given role + scope.
+ * `unfiltered` = no predicate (admin, no scope). `empty` = the caller must
+ * short-circuit to an empty result rather than emit an unbounded query or an
+ * `IN ()` list, which is invalid MySQL.
+ */
+type EmployeeScopeResolution =
+  | { kind: 'unfiltered' }
+  | { kind: 'empty' }
+  | { kind: 'equals'; id: number }
+  | { kind: 'in'; ids: number[] }
+
 export interface PayrollFilters {
   employeeId?: number
   vendorId?: number
@@ -20,6 +56,7 @@ export interface PayrollFilters {
   startDate?: string
   endDate?: string
   status?: 'paid' | 'unpaid' | 'all'
+  scope?: PayrollScope
   page?: number
   limit?: number
 }
@@ -168,7 +205,70 @@ export interface PaystubDeletionResult {
  * Repository for payroll-related data operations
  */
 export class PayrollRepository {
-  
+
+  /**
+   * Resolve the employees.id predicate for a list query from the user's role
+   * and an optional `scope` narrowing.
+   *
+   * The role filter is resolved to its id set FIRST, then `scope` is applied as
+   * an intersection against that set. This is what makes it impossible for any
+   * `scope` value to widen access:
+   *
+   *   - no scope        → today's behaviour, unchanged (admin unfiltered,
+   *                       manager `IN (self + reports)`, employee `= self`)
+   *   - scope 'mine'    → base ∩ [employeeId]        (no employeeId ⇒ empty)
+   *   - scope 'team'    → base ∩ managedEmployeeIds  (no reports  ⇒ empty)
+   *
+   * A non-manager passing `scope: 'team'` intersects their `[self]` base with
+   * an empty managed list and gets `empty`, never their peers' rows. Admins are
+   * narrowed too: their base is unbounded, so the intersection is the scope set
+   * itself.
+   */
+  private resolveEmployeeScope(
+    scope: PayrollScope | undefined,
+    userContext: {
+      isAdmin: boolean
+      isManager: boolean
+      employeeId?: number
+      managedEmployeeIds?: number[]
+    }
+  ): EmployeeScopeResolution {
+    // The id set the caller asked to narrow to. `null` = no narrowing requested.
+    // Anything outside the union is treated as no narrowing (safe default).
+    const scopeIds: number[] | null =
+      scope === 'mine'
+        ? (userContext.employeeId ? [userContext.employeeId] : [])
+        : scope === 'team'
+          ? [...new Set(userContext.managedEmployeeIds ?? [])]
+          : null
+
+    // Admins have an unbounded base set, so base ∩ scope === scope.
+    if (userContext.isAdmin) {
+      if (scopeIds === null) return { kind: 'unfiltered' }
+      return scopeIds.length ? { kind: 'in', ids: scopeIds } : { kind: 'empty' }
+    }
+
+    // Managers see themselves AND their subordinates.
+    const accessibleIds = accessibleEmployeeIds(userContext)
+
+    if (userContext.isManager && accessibleIds.length) {
+      if (scopeIds === null) return { kind: 'in', ids: accessibleIds }
+      const narrowed = scopeIds.filter(id => accessibleIds.includes(id))
+      return narrowed.length ? { kind: 'in', ids: narrowed } : { kind: 'empty' }
+    }
+
+    if (userContext.employeeId) {
+      // Base is exactly [self]; the intersection is either [self] or nothing.
+      if (scopeIds === null || scopeIds.includes(userContext.employeeId)) {
+        return { kind: 'equals', id: userContext.employeeId }
+      }
+      return { kind: 'empty' }
+    }
+
+    // No access at all.
+    return { kind: 'empty' }
+  }
+
   /**
    * Get payroll summary data with role-based filtering and pagination
    */
@@ -214,34 +314,35 @@ export class PayrollRepository {
         'paystubs.issue_date'
       ])
 
-    // Apply role-based filtering
-    if (!userContext.isAdmin) {
-      // Managers see themselves AND their subordinates
-      const accessibleIds = accessibleEmployeeIds(userContext)
+    // Apply role-based filtering, narrowed by `scope` where requested.
+    // `scope` intersects the role-resolved id set — it can only remove rows.
+    const employeeScope = this.resolveEmployeeScope(filters.scope, userContext)
 
-      if (userContext.isManager && accessibleIds.length) {
-        query = query.where('employees.id', 'in', accessibleIds)
-      } else if (userContext.employeeId) {
-        query = query.where('employees.id', '=', userContext.employeeId)
-      } else {
-        // No access - return empty results
-        return {
-          data: [],
-          pagination: {
-            page,
-            limit,
-            total: 0,
-            totalPages: 0,
-            hasNext: false,
-            hasPrev: false
-          }
+    if (employeeScope.kind === 'empty') {
+      // No access, or the scope intersects the accessible set to nothing.
+      // Short-circuit rather than emitting an unbounded query or `IN ()`.
+      return {
+        data: [],
+        pagination: {
+          page,
+          limit,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false
         }
       }
+    }
 
-      // Hide unreleased (future-dated) paystubs from non-admins
-      if (issueDateCutoff) {
-        query = query.where(db.fn('DATE', ['paystubs.issue_date']), '<=', issueDateCutoff)
-      }
+    if (employeeScope.kind === 'in') {
+      query = query.where('employees.id', 'in', employeeScope.ids)
+    } else if (employeeScope.kind === 'equals') {
+      query = query.where('employees.id', '=', employeeScope.id)
+    }
+
+    // Hide unreleased (future-dated) paystubs from non-admins
+    if (!userContext.isAdmin && issueDateCutoff) {
+      query = query.where(db.fn('DATE', ['paystubs.issue_date']), '<=', issueDateCutoff)
     }
 
     // Apply additional filters
@@ -274,21 +375,17 @@ export class PayrollRepository {
       .leftJoin('employees', 'paystubs.agent_id', 'employees.id')
       .leftJoin('vendors', 'paystubs.vendor_id', 'vendors.id')
 
-    // Apply the same role-based filtering to count query
-    if (!userContext.isAdmin) {
-      // Managers see themselves AND their subordinates
-      const accessibleIds = accessibleEmployeeIds(userContext)
+    // Apply the same role-based filtering (and the same scope narrowing) to the
+    // count query, so pagination never advertises rows the data query hides.
+    if (employeeScope.kind === 'in') {
+      countQuery = countQuery.where('employees.id', 'in', employeeScope.ids)
+    } else if (employeeScope.kind === 'equals') {
+      countQuery = countQuery.where('employees.id', '=', employeeScope.id)
+    }
 
-      if (userContext.isManager && accessibleIds.length) {
-        countQuery = countQuery.where('employees.id', 'in', accessibleIds)
-      } else if (userContext.employeeId) {
-        countQuery = countQuery.where('employees.id', '=', userContext.employeeId)
-      }
-
-      // Hide unreleased (future-dated) paystubs from non-admins
-      if (issueDateCutoff) {
-        countQuery = countQuery.where(db.fn('DATE', ['paystubs.issue_date']), '<=', issueDateCutoff)
-      }
+    // Hide unreleased (future-dated) paystubs from non-admins
+    if (!userContext.isAdmin && issueDateCutoff) {
+      countQuery = countQuery.where(db.fn('DATE', ['paystubs.issue_date']), '<=', issueDateCutoff)
     }
 
     // Apply the same additional filters to count query
@@ -664,7 +761,11 @@ export class PayrollRepository {
   }
 
   /**
-   * Get available issue dates for role-based access
+   * Get available issue dates for role-based access.
+   *
+   * NOTE: `PayrollFilters.scope` is deliberately NOT applied here. The issue
+   * dates populate the filter dropdown, which should keep offering every date
+   * the user can reach regardless of which scope tab is active.
    */
   async getAvailableIssueDates(
     userContext: {

--- a/src/lib/repositories/PayrollRepository.ts
+++ b/src/lib/repositories/PayrollRepository.ts
@@ -4,7 +4,7 @@ import { AdvanceRepository } from '@/lib/repositories/AdvanceRepository'
 import { VendorFieldRepository } from '@/lib/repositories/VendorFieldRepository'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { logger } from '@/lib/utils/logger'
-import type { UserContext } from '@/lib/auth/types'
+import { accessibleEmployeeIds, type UserContext } from '@/lib/auth/types'
 import {
   getEmployeeVisibilityCutoff,
   DEFAULT_RELEASE_HOUR,
@@ -216,8 +216,11 @@ export class PayrollRepository {
 
     // Apply role-based filtering
     if (!userContext.isAdmin) {
-      if (userContext.isManager && userContext.managedEmployeeIds?.length) {
-        query = query.where('employees.id', 'in', userContext.managedEmployeeIds)
+      // Managers see themselves AND their subordinates
+      const accessibleIds = accessibleEmployeeIds(userContext)
+
+      if (userContext.isManager && accessibleIds.length) {
+        query = query.where('employees.id', 'in', accessibleIds)
       } else if (userContext.employeeId) {
         query = query.where('employees.id', '=', userContext.employeeId)
       } else {
@@ -273,8 +276,11 @@ export class PayrollRepository {
 
     // Apply the same role-based filtering to count query
     if (!userContext.isAdmin) {
-      if (userContext.isManager && userContext.managedEmployeeIds?.length) {
-        countQuery = countQuery.where('employees.id', 'in', userContext.managedEmployeeIds)
+      // Managers see themselves AND their subordinates
+      const accessibleIds = accessibleEmployeeIds(userContext)
+
+      if (userContext.isManager && accessibleIds.length) {
+        countQuery = countQuery.where('employees.id', 'in', accessibleIds)
       } else if (userContext.employeeId) {
         countQuery = countQuery.where('employees.id', '=', userContext.employeeId)
       }
@@ -676,8 +682,11 @@ export class PayrollRepository {
 
     // Apply role-based filtering
     if (!userContext.isAdmin) {
-      if (userContext.isManager && userContext.managedEmployeeIds?.length) {
-        query = query.where('employees.id', 'in', userContext.managedEmployeeIds)
+      // Managers see themselves AND their subordinates
+      const accessibleIds = accessibleEmployeeIds(userContext)
+
+      if (userContext.isManager && accessibleIds.length) {
+        query = query.where('employees.id', 'in', accessibleIds)
       } else if (userContext.employeeId) {
         query = query.where('employees.id', '=', userContext.employeeId)
       } else {

--- a/src/lib/repositories/__tests__/InvoiceRepository.rbac.test.ts
+++ b/src/lib/repositories/__tests__/InvoiceRepository.rbac.test.ts
@@ -81,6 +81,24 @@ const managerCtx: UserContext = {
   managedEmployeeIds: [10, 11],
 }
 const employeeCtx: UserContext = { employeeId: 3, isAdmin: false, isManager: false }
+// Manager who has been granted the manager flag but has zero direct reports.
+const managerNoReportsCtx: UserContext = {
+  employeeId: 4,
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [],
+}
+// Same, but the caller never populated managedEmployeeIds at all.
+const managerUndefinedReportsCtx: UserContext = {
+  employeeId: 5,
+  isAdmin: false,
+  isManager: true,
+}
+
+// Helpers over the shared chainable mock
+const tablesQueried = () => mockChain.selectFrom.mock.calls.map((call) => call[0])
+const idInFilters = () =>
+  mockChain.where.mock.calls.filter((call) => call[0] === 'id' && call[1] === 'in')
 
 describe('InvoiceRepository RBAC', () => {
   // Test both repository files
@@ -109,6 +127,46 @@ describe('InvoiceRepository RBAC', () => {
 
       it('does not throw for admin', async () => {
         await expect(repo.getInvoicePageResources(adminCtx)).resolves.toBeDefined()
+      })
+
+      it('filters agents to the direct reports of a manager with reports', async () => {
+        await repo.getInvoicePageResources(managerCtx)
+
+        expect(tablesQueried()).toContain('employees')
+        expect(idInFilters()).toEqual([['id', 'in', [10, 11]]])
+      })
+
+      it('applies no employee filter for admin', async () => {
+        await repo.getInvoicePageResources(adminCtx)
+
+        expect(tablesQueried()).toContain('employees')
+        expect(idInFilters()).toHaveLength(0)
+      })
+
+      it('fails closed with an empty agent list for a manager with zero reports', async () => {
+        const result = await repo.getInvoicePageResources(managerNoReportsCtx)
+
+        expect(result.agents).toEqual([])
+        // The unfiltered employees query must never run
+        expect(tablesQueried()).not.toContain('employees')
+        expect(idInFilters()).toHaveLength(0)
+      })
+
+      it('fails closed when managedEmployeeIds is undefined', async () => {
+        const result = await repo.getInvoicePageResources(managerUndefinedReportsCtx)
+
+        expect(result.agents).toEqual([])
+        expect(tablesQueried()).not.toContain('employees')
+        expect(idInFilters()).toHaveLength(0)
+      })
+
+      it('still returns vendors and issue dates when the agent list is empty', async () => {
+        const result = await repo.getInvoicePageResources(managerNoReportsCtx)
+
+        expect(result.agents).toEqual([])
+        expect(tablesQueried()).toContain('vendors')
+        expect(Array.isArray(result.vendors)).toBe(true)
+        expect(Array.isArray(result.issueDates)).toBe(true)
       })
     })
 

--- a/src/lib/repositories/__tests__/PayrollRepository.manager-self.test.ts
+++ b/src/lib/repositories/__tests__/PayrollRepository.manager-self.test.ts
@@ -1,0 +1,261 @@
+import type { UserContext } from '@/lib/auth/types'
+
+type MockChain = Record<string, jest.Mock>
+
+// eslint-disable-next-line no-var
+var mockChain: MockChain
+
+jest.mock('@/lib/database/client', () => {
+  mockChain = {
+    selectFrom: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    selectAll: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue([]),
+    executeTakeFirst: jest.fn().mockResolvedValue(null),
+    fn: Object.assign(jest.fn().mockReturnValue('DATE_EXPR'), {
+      count: jest.fn().mockReturnValue({ as: jest.fn() }),
+      sum: jest.fn().mockReturnValue({ as: jest.fn() }),
+      max: jest.fn().mockReturnValue({ as: jest.fn() }),
+    }),
+  }
+  return { db: mockChain }
+})
+
+jest.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: jest.fn().mockResolvedValue(false),
+}))
+
+jest.mock('../VendorFieldRepository', () => ({
+  VendorFieldRepository: jest.fn().mockImplementation(() => ({
+    getActiveFieldsForDisplay: jest.fn().mockResolvedValue([]),
+  })),
+}))
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}))
+
+import { PayrollRepository } from '../PayrollRepository'
+
+// Ralph Barker in the production snapshot: employees.id 36, is_mgr = 1, with a
+// single subordinate (1184). manager_employees never contains self, so before
+// the fix his own 844 paystubs were filtered out of every manager-branch list.
+const SELF = 36
+const SUBORDINATE = 1184
+
+const adminCtx: UserContext = { employeeId: 1, isAdmin: true, isManager: false }
+const managerCtx: UserContext = {
+  employeeId: SELF,
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [SUBORDINATE],
+}
+const managerNoReportsCtx: UserContext = {
+  employeeId: SELF,
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [],
+}
+const employeeCtx: UserContext = { employeeId: 7, isAdmin: false, isManager: false }
+const orphanManagerCtx: UserContext = { isAdmin: false, isManager: true }
+
+/** Every role-filter predicate applied against the employees table. */
+function employeeIdFilters() {
+  return mockChain.where.mock.calls.filter((call: unknown[]) => call[0] === 'employees.id')
+}
+
+/**
+ * Every unreleased-paystub cutoff predicate: `DATE(paystubs.issue_date) <= cutoff`.
+ * The mocked `db.fn(...)` collapses the DATE expression to the 'DATE_EXPR' sentinel.
+ * No date filters are passed in these tests, so the only '<=' predicates on
+ * 'DATE_EXPR' are the release-date cutoffs.
+ */
+function issueDateCutoffFilters() {
+  return mockChain.where.mock.calls.filter(
+    (call: unknown[]) => call[0] === 'DATE_EXPR' && call[1] === '<='
+  )
+}
+
+describe('PayrollRepository role filtering includes the manager themselves', () => {
+  let repo: PayrollRepository
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockChain.execute.mockResolvedValue([])
+    mockChain.executeTakeFirst.mockResolvedValue(null)
+    repo = new PayrollRepository()
+  })
+
+  describe('getPayrollSummary', () => {
+    it('scopes a manager to self AND subordinates on both the data and count query', async () => {
+      await repo.getPayrollSummary({}, managerCtx)
+
+      const filters = employeeIdFilters()
+      // One for the paginated data query, one for the count query
+      expect(filters).toHaveLength(2)
+      for (const call of filters) {
+        expect(call).toEqual(['employees.id', 'in', [SELF, SUBORDINATE]])
+      }
+    })
+
+    it('scopes a manager with zero subordinates to self only', async () => {
+      await repo.getPayrollSummary({}, managerNoReportsCtx)
+
+      const filters = employeeIdFilters()
+      expect(filters).toHaveLength(2)
+      for (const call of filters) {
+        expect(call).toEqual(['employees.id', 'in', [SELF]])
+      }
+    })
+
+    it('dedupes when managedEmployeeIds already contains the manager', async () => {
+      await repo.getPayrollSummary(
+        {},
+        { ...managerCtx, managedEmployeeIds: [SELF, SUBORDINATE] }
+      )
+
+      const filters = employeeIdFilters()
+      expect(filters).toHaveLength(2)
+      for (const call of filters) {
+        expect(call).toEqual(['employees.id', 'in', [SELF, SUBORDINATE]])
+      }
+    })
+
+    it('applies no employee filter for admins', async () => {
+      await repo.getPayrollSummary({}, adminCtx)
+      expect(employeeIdFilters()).toHaveLength(0)
+    })
+
+    it('still scopes a plain employee to an equality match on self', async () => {
+      await repo.getPayrollSummary({}, employeeCtx)
+
+      const filters = employeeIdFilters()
+      expect(filters).toHaveLength(2)
+      for (const call of filters) {
+        expect(call).toEqual(['employees.id', '=', 7])
+      }
+    })
+
+    it('returns no data for a manager with neither employeeId nor subordinates', async () => {
+      const result = await repo.getPayrollSummary({}, orphanManagerCtx)
+
+      expect(result.data).toEqual([])
+      expect(result.pagination.total).toBe(0)
+      expect(employeeIdFilters()).toHaveLength(0)
+    })
+  })
+
+  describe('getAvailableIssueDates', () => {
+    it('scopes a manager to self AND subordinates', async () => {
+      await repo.getAvailableIssueDates(managerCtx)
+
+      expect(employeeIdFilters()).toEqual([
+        ['employees.id', 'in', [SELF, SUBORDINATE]],
+      ])
+    })
+
+    it('scopes a manager with zero subordinates to self only', async () => {
+      await repo.getAvailableIssueDates(managerNoReportsCtx)
+
+      expect(employeeIdFilters()).toEqual([['employees.id', 'in', [SELF]]])
+    })
+
+    it('applies no employee filter for admins', async () => {
+      await repo.getAvailableIssueDates(adminCtx)
+      expect(employeeIdFilters()).toHaveLength(0)
+    })
+
+    it('still scopes a plain employee to an equality match on self', async () => {
+      await repo.getAvailableIssueDates(employeeCtx)
+
+      expect(employeeIdFilters()).toEqual([['employees.id', '=', 7]])
+    })
+
+    it('returns an empty list for a manager with neither employeeId nor subordinates', async () => {
+      const result = await repo.getAvailableIssueDates(orphanManagerCtx)
+
+      expect(result).toEqual([])
+      expect(employeeIdFilters()).toHaveLength(0)
+    })
+  })
+
+  // Widening the manager scope to include self must not weaken the OTHER
+  // non-admin guard on the same code path: future-dated paystubs stay hidden
+  // until their release time. Both predicates have to survive together.
+  describe('release-date cutoff AND-combines with the widened manager scope', () => {
+    const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+    it('getPayrollSummary applies the manager IN-list AND the cutoff on the data query and the count query', async () => {
+      await repo.getPayrollSummary({}, managerCtx)
+
+      const idFilters = employeeIdFilters()
+      const cutoffFilters = issueDateCutoffFilters()
+
+      // Two of each: one pair for the paginated data query, one for the count query
+      expect(idFilters).toHaveLength(2)
+      expect(cutoffFilters).toHaveLength(2)
+
+      for (const call of idFilters) {
+        expect(call).toEqual(['employees.id', 'in', [SELF, SUBORDINATE]])
+      }
+      for (const call of cutoffFilters) {
+        expect(call[2]).toEqual(expect.stringMatching(ISO_DATE))
+      }
+
+      // The cutoff is built from DATE(paystubs.issue_date), not a raw column
+      expect(mockChain.fn).toHaveBeenCalledWith('DATE', ['paystubs.issue_date'])
+    })
+
+    it('getPayrollSummary keeps the cutoff for a manager with zero subordinates', async () => {
+      await repo.getPayrollSummary({}, managerNoReportsCtx)
+
+      expect(employeeIdFilters()).toHaveLength(2)
+      expect(issueDateCutoffFilters()).toHaveLength(2)
+    })
+
+    it('getAvailableIssueDates applies the manager IN-list AND the cutoff', async () => {
+      await repo.getAvailableIssueDates(managerCtx)
+
+      expect(employeeIdFilters()).toEqual([
+        ['employees.id', 'in', [SELF, SUBORDINATE]],
+      ])
+
+      const cutoffFilters = issueDateCutoffFilters()
+      expect(cutoffFilters).toHaveLength(1)
+      expect(cutoffFilters[0][2]).toEqual(expect.stringMatching(ISO_DATE))
+
+      expect(mockChain.fn).toHaveBeenCalledWith('DATE', ['paystubs.issue_date'])
+    })
+
+    it('getAvailableIssueDates keeps the cutoff for a manager with zero subordinates', async () => {
+      await repo.getAvailableIssueDates(managerNoReportsCtx)
+
+      expect(employeeIdFilters()).toEqual([['employees.id', 'in', [SELF]]])
+      expect(issueDateCutoffFilters()).toHaveLength(1)
+    })
+
+    it('still applies the cutoff to plain employees', async () => {
+      await repo.getPayrollSummary({}, employeeCtx)
+      expect(issueDateCutoffFilters()).toHaveLength(2)
+    })
+
+    // Negative control: proves issueDateCutoffFilters() actually tracks the
+    // cutoff predicate rather than matching unconditionally.
+    it('never applies the cutoff for admins', async () => {
+      await repo.getPayrollSummary({}, adminCtx)
+      expect(issueDateCutoffFilters()).toHaveLength(0)
+
+      jest.clearAllMocks()
+
+      await repo.getAvailableIssueDates(adminCtx)
+      expect(issueDateCutoffFilters()).toHaveLength(0)
+    })
+  })
+})

--- a/src/lib/repositories/__tests__/PayrollRepository.scope.test.ts
+++ b/src/lib/repositories/__tests__/PayrollRepository.scope.test.ts
@@ -1,0 +1,404 @@
+import type { UserContext } from '@/lib/auth/types'
+
+type MockChain = Record<string, jest.Mock>
+
+// eslint-disable-next-line no-var
+var mockChain: MockChain
+
+jest.mock('@/lib/database/client', () => {
+  mockChain = {
+    selectFrom: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    selectAll: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue([]),
+    executeTakeFirst: jest.fn().mockResolvedValue(null),
+    fn: Object.assign(jest.fn().mockReturnValue('DATE_EXPR'), {
+      count: jest.fn().mockReturnValue({ as: jest.fn() }),
+      sum: jest.fn().mockReturnValue({ as: jest.fn() }),
+      max: jest.fn().mockReturnValue({ as: jest.fn() }),
+    }),
+  }
+  return { db: mockChain }
+})
+
+jest.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: jest.fn().mockResolvedValue(false),
+}))
+
+jest.mock('../VendorFieldRepository', () => ({
+  VendorFieldRepository: jest.fn().mockImplementation(() => ({
+    getActiveFieldsForDisplay: jest.fn().mockResolvedValue([]),
+  })),
+}))
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}))
+
+import { PayrollRepository, parsePayrollScope, type PayrollScope } from '../PayrollRepository'
+
+// Ralph Barker in the production snapshot: employees.id 36, is_mgr = 1, one
+// subordinate (1184). `manager_employees` never contains self.
+const SELF = 36
+const SUBORDINATE = 1184
+const SECOND_SUBORDINATE = 2001
+
+const adminCtx: UserContext = { employeeId: 1, isAdmin: true, isManager: false }
+const adminWithReportsCtx: UserContext = {
+  employeeId: 1,
+  isAdmin: true,
+  isManager: true,
+  managedEmployeeIds: [SUBORDINATE],
+}
+const adminNoEmployeeCtx: UserContext = { isAdmin: true, isManager: false }
+const managerCtx: UserContext = {
+  employeeId: SELF,
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [SUBORDINATE, SECOND_SUBORDINATE],
+}
+const managerNoReportsCtx: UserContext = {
+  employeeId: SELF,
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [],
+}
+const managerNoEmployeeIdCtx: UserContext = {
+  isAdmin: false,
+  isManager: true,
+  managedEmployeeIds: [SUBORDINATE],
+}
+const employeeCtx: UserContext = { employeeId: 7, isAdmin: false, isManager: false }
+
+/**
+ * A NON-manager carrying a populated `managedEmployeeIds`. This is the case
+ * where the intersection is load-bearing: the ids exist on the context but the
+ * role filter does not grant them, so `scope: 'team'` must resolve to nothing.
+ * If `resolveEmployeeScope` ever substituted the scope set for the role-resolved
+ * set instead of intersecting, this context would leak employees 99 and 100.
+ */
+const employeeWithStaleReportsCtx: UserContext = {
+  employeeId: 7,
+  isAdmin: false,
+  isManager: false,
+  managedEmployeeIds: [99, 100],
+}
+
+/** Every role-filter predicate applied against the employees table. */
+function employeeIdFilters() {
+  return mockChain.where.mock.calls.filter((call: unknown[]) => call[0] === 'employees.id')
+}
+
+/** The unreleased-paystub cutoff predicates: `DATE(paystubs.issue_date) <= cutoff`. */
+function issueDateCutoffFilters() {
+  return mockChain.where.mock.calls.filter(
+    (call: unknown[]) => call[0] === 'DATE_EXPR' && call[1] === '<='
+  )
+}
+
+/** Normalise an employees.id predicate ('=' or 'in') to the id set it permits. */
+function idsFromFilter(call: unknown[]): number[] {
+  return call[1] === 'in' ? (call[2] as number[]) : [call[2] as number]
+}
+
+interface SummaryRun {
+  idFilters: unknown[][]
+  cutoffFilters: unknown[][]
+  /** Permitted id set, or `null` when no employees.id predicate was emitted. */
+  ids: number[] | null
+  /** True when the repository returned early instead of running the data query. */
+  shortCircuited: boolean
+  total: number
+}
+
+async function runSummary(userContext: UserContext, scope?: PayrollScope): Promise<SummaryRun> {
+  jest.clearAllMocks()
+  mockChain.execute.mockResolvedValue([])
+  mockChain.executeTakeFirst.mockResolvedValue(null)
+
+  const repo = new PayrollRepository()
+  const result = await repo.getPayrollSummary(scope === undefined ? {} : { scope }, userContext)
+
+  const idFilters = employeeIdFilters()
+
+  return {
+    idFilters,
+    cutoffFilters: issueDateCutoffFilters(),
+    ids: idFilters.length === 0 ? null : idsFromFilter(idFilters[0]),
+    // The data query only reaches `.limit()` when we did not return early.
+    shortCircuited: mockChain.limit.mock.calls.length === 0,
+    total: result.pagination.total,
+  }
+}
+
+describe('getPayrollSummary scope narrowing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockChain.execute.mockResolvedValue([])
+    mockChain.executeTakeFirst.mockResolvedValue(null)
+  })
+
+  describe("scope: 'mine'", () => {
+    it('narrows a manager to exactly [self] on BOTH the data and the count query', async () => {
+      const run = await runSummary(managerCtx, 'mine')
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(idsFromFilter(call)).toEqual([SELF])
+      }
+      expect(run.shortCircuited).toBe(false)
+    })
+
+    it('keeps the release-date cutoff on both queries when narrowing a manager', async () => {
+      const run = await runSummary(managerCtx, 'mine')
+
+      expect(run.cutoffFilters).toHaveLength(2)
+      for (const call of run.cutoffFilters) {
+        expect(call[2]).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/))
+      }
+      expect(mockChain.fn).toHaveBeenCalledWith('DATE', ['paystubs.issue_date'])
+    })
+
+    it('returns an empty result — never an unfiltered query — when there is no employeeId', async () => {
+      const run = await runSummary(managerNoEmployeeIdCtx, 'mine')
+
+      expect(run.total).toBe(0)
+      expect(run.shortCircuited).toBe(true)
+      expect(run.idFilters).toHaveLength(0)
+    })
+  })
+
+  describe("scope: 'team'", () => {
+    it('narrows a manager to exactly their reports, with self excluded', async () => {
+      const run = await runSummary(managerCtx, 'team')
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(idsFromFilter(call)).toEqual([SUBORDINATE, SECOND_SUBORDINATE])
+        expect(idsFromFilter(call)).not.toContain(SELF)
+      }
+    })
+
+    it('keeps the release-date cutoff on both queries when narrowing a manager', async () => {
+      const run = await runSummary(managerCtx, 'team')
+      expect(run.cutoffFilters).toHaveLength(2)
+    })
+
+    it('returns an empty result with no IN () list when the manager has zero reports', async () => {
+      const run = await runSummary(managerNoReportsCtx, 'team')
+
+      expect(run.total).toBe(0)
+      expect(run.shortCircuited).toBe(true)
+      expect(run.idFilters).toHaveLength(0)
+
+      // An empty IN list is invalid MySQL — it must never be emitted.
+      const emptyInLists = mockChain.where.mock.calls.filter(
+        (call: unknown[]) => call[1] === 'in' && Array.isArray(call[2]) && call[2].length === 0
+      )
+      expect(emptyInLists).toHaveLength(0)
+    })
+  })
+
+  describe('scope undefined is a byte-identical regression guard', () => {
+    it('still scopes a manager to self AND subordinates', async () => {
+      const run = await runSummary(managerCtx)
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(call).toEqual(['employees.id', 'in', [SELF, SUBORDINATE, SECOND_SUBORDINATE]])
+      }
+      expect(run.cutoffFilters).toHaveLength(2)
+    })
+
+    it('still scopes a plain employee to an equality match on self', async () => {
+      const run = await runSummary(employeeCtx)
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(call).toEqual(['employees.id', '=', 7])
+      }
+    })
+
+    it('still leaves admins completely unfiltered with no cutoff', async () => {
+      const run = await runSummary(adminCtx)
+
+      expect(run.idFilters).toHaveLength(0)
+      expect(run.cutoffFilters).toHaveLength(0)
+      expect(run.shortCircuited).toBe(false)
+    })
+  })
+
+  describe('SECURITY: scope can only narrow, never widen', () => {
+    it('gives a plain employee passing scope: team an empty result, not their peers rows', async () => {
+      const run = await runSummary(employeeCtx, 'team')
+
+      expect(run.total).toBe(0)
+      expect(run.shortCircuited).toBe(true)
+      expect(run.idFilters).toHaveLength(0)
+    })
+
+    it('leaves a plain employee passing scope: mine pinned to their own id', async () => {
+      const run = await runSummary(employeeCtx, 'mine')
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(idsFromFilter(call)).toEqual([7])
+      }
+    })
+
+    // MUTATION GUARD: these two fail if resolveEmployeeScope is changed from
+    // `scopeIds ∩ base` to plain substitution (`scopeIds`) — the textbook
+    // privilege-escalation regression. The role filter does not grant 99/100,
+    // so no scope value may surface them.
+    it('gives a non-manager carrying managedEmployeeIds an empty result for scope: team', async () => {
+      const run = await runSummary(employeeWithStaleReportsCtx, 'team')
+
+      expect(run.total).toBe(0)
+      expect(run.shortCircuited).toBe(true)
+      expect(run.idFilters).toHaveLength(0)
+
+      // Belt and braces: 99/100 must appear in no predicate whatsoever.
+      const leaked = mockChain.where.mock.calls.filter((call: unknown[]) =>
+        JSON.stringify(call).includes('99') || JSON.stringify(call).includes('100')
+      )
+      expect(leaked).toHaveLength(0)
+    })
+
+    it('keeps a non-manager carrying managedEmployeeIds pinned to self for scope: mine', async () => {
+      const run = await runSummary(employeeWithStaleReportsCtx, 'mine')
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(idsFromFilter(call)).toEqual([7])
+        expect(idsFromFilter(call)).not.toContain(99)
+        expect(idsFromFilter(call)).not.toContain(100)
+      }
+    })
+
+    it('narrows an admin passing scope: mine to their own employee id', async () => {
+      const run = await runSummary(adminCtx, 'mine')
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(idsFromFilter(call)).toEqual([1])
+      }
+    })
+
+    it('narrows an admin passing scope: team to their managed ids only', async () => {
+      const run = await runSummary(adminWithReportsCtx, 'team')
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(idsFromFilter(call)).toEqual([SUBORDINATE])
+      }
+    })
+
+    it('gives an admin with no employeeId and scope: mine an empty result, not an unfiltered query', async () => {
+      const run = await runSummary(adminNoEmployeeCtx, 'mine')
+
+      expect(run.total).toBe(0)
+      expect(run.shortCircuited).toBe(true)
+      expect(run.idFilters).toHaveLength(0)
+    })
+
+    it('gives an admin with no reports and scope: team an empty result, not an unfiltered query', async () => {
+      const run = await runSummary(adminCtx, 'team')
+
+      expect(run.total).toBe(0)
+      expect(run.shortCircuited).toBe(true)
+      expect(run.idFilters).toHaveLength(0)
+    })
+
+    it('never permits an id the unscoped query would not have permitted, for any role/scope pair', async () => {
+      const contexts: Array<[string, UserContext]> = [
+        ['admin', adminCtx],
+        ['admin with reports', adminWithReportsCtx],
+        ['manager', managerCtx],
+        ['manager without reports', managerNoReportsCtx],
+        ['employee', employeeCtx],
+        ['non-manager with stale managedEmployeeIds', employeeWithStaleReportsCtx],
+      ]
+
+      for (const [label, ctx] of contexts) {
+        const baseline = await runSummary(ctx)
+
+        for (const scope of ['mine', 'team'] as const) {
+          const scoped = await runSummary(ctx, scope)
+
+          if (scoped.shortCircuited) {
+            // Empty result is always a valid narrowing.
+            expect(scoped.ids).toBeNull()
+            continue
+          }
+
+          expect(scoped.ids).not.toBeNull()
+
+          if (baseline.ids === null) {
+            // Admin baseline is unbounded, so any finite set is a narrowing —
+            // but it must still be finite, i.e. an actual predicate was added.
+            expect(baseline.shortCircuited).toBe(false)
+            continue
+          }
+
+          for (const id of scoped.ids as number[]) {
+            expect(baseline.ids).toContain(id)
+          }
+          expect((scoped.ids as number[]).length).toBeLessThanOrEqual(baseline.ids.length)
+          // Sanity: the label is only here to make failures legible.
+          expect(typeof label).toBe('string')
+        }
+      }
+    })
+
+    it('treats an out-of-union scope value as no narrowing rather than widening', async () => {
+      const run = await runSummary(employeeCtx, 'everyone' as unknown as PayrollScope)
+
+      expect(run.idFilters).toHaveLength(2)
+      for (const call of run.idFilters) {
+        expect(call).toEqual(['employees.id', '=', 7])
+      }
+    })
+  })
+})
+
+describe('parsePayrollScope (page-level searchParams validation)', () => {
+  it('accepts the two literal union members', () => {
+    expect(parsePayrollScope('mine')).toBe('mine')
+    expect(parsePayrollScope('team')).toBe('team')
+  })
+
+  it('treats a garbage value as undefined', () => {
+    expect(parsePayrollScope('everyone')).toBeUndefined()
+    expect(parsePayrollScope('all')).toBeUndefined()
+    expect(parsePayrollScope("team' OR 1=1--")).toBeUndefined()
+    expect(parsePayrollScope('')).toBeUndefined()
+  })
+
+  it('is case sensitive', () => {
+    expect(parsePayrollScope('Mine')).toBeUndefined()
+    expect(parsePayrollScope('TEAM')).toBeUndefined()
+  })
+
+  it('treats missing and non-string values as undefined', () => {
+    expect(parsePayrollScope(undefined)).toBeUndefined()
+    expect(parsePayrollScope(null)).toBeUndefined()
+    expect(parsePayrollScope(['team'])).toBeUndefined()
+    expect(parsePayrollScope(1)).toBeUndefined()
+  })
+
+  it('feeds a validated garbage value into the repository as unscoped access', async () => {
+    const run = await runSummary(managerCtx, parsePayrollScope('nonsense'))
+
+    expect(run.idFilters).toHaveLength(2)
+    for (const call of run.idFilters) {
+      expect(call).toEqual(['employees.id', 'in', [SELF, SUBORDINATE, SECOND_SUBORDINATE]])
+    }
+  })
+})

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ Comprehensive Playwright testing framework now operational for the Choice Market
 ### ✅ Authentication Testing
 - **Login Flow Validation**: All user roles tested across browsers
 - **Client Hydration Handling**: Proper wait for form availability
-- **Role-Based Redirects**: Admin → `/admin`, Manager → `/manager`, Employee → `/dashboard`
+- **Role-Based Redirects**: Admin → `/admin`, Manager → `/dashboard`, Employee → `/dashboard`
 - **Cross-Browser Compatibility**: Chrome, Firefox, Safari, Mobile Safari, Mobile Chrome
 
 ### ✅ Test Categories Implemented

--- a/tests/e2e/admin-functions.spec.ts
+++ b/tests/e2e/admin-functions.spec.ts
@@ -190,9 +190,9 @@ test.describe('Admin Functions - Core Operations', () => {
       await page.waitForLoadState('networkidle')
       
       // Should show managers and employees
-      const hasManagers = await page.locator('text=Admin User').first().isVisible() ||
-                         await page.locator('text=Manager User').first().isVisible()
-      const hasEmployees = await page.locator('text=Employee User').first().isVisible()
+      const hasManagers = await page.locator('text=Test Admin').first().isVisible() ||
+                         await page.locator('text=Test Manager').first().isVisible()
+      const hasEmployees = await page.locator('text=Test Employee').first().isVisible()
       
       expect(hasManagers || hasEmployees).toBeTruthy()
     })

--- a/tests/e2e/auth-system.spec.ts
+++ b/tests/e2e/auth-system.spec.ts
@@ -15,17 +15,18 @@ test.describe('Authentication System', () => {
     await expect(page.locator('h1')).toContainText('Admin Dashboard');
   });
 
-  test('should login as manager and access manager dashboard', async ({ page }) => {
+  test('should login as manager and land on the shared dashboard', async ({ page }) => {
     const auth = new AuthHelper(page);
-    
+
     // Test manager login
     await auth.loginAsManager();
-    
-    // Verify we're on manager dashboard
-    await expect(page).toHaveURL('/manager/dashboard');
-    
-    // Check for manager-specific content
-    await expect(page.locator('h1')).toContainText('Manager Dashboard');
+
+    // Managers land on /dashboard alongside reps — that is where their own pay
+    // section and the link into their team's pay live.
+    await expect(page).toHaveURL('/dashboard');
+
+    // Check for the dashboard's welcome heading (seeded manager: 'Manager User')
+    await expect(page.locator('h1')).toContainText('Welcome, Manager User!');
   });
 
   test('should login as employee and access regular dashboard', async ({ page }) => {

--- a/tests/e2e/auth-system.spec.ts
+++ b/tests/e2e/auth-system.spec.ts
@@ -25,8 +25,8 @@ test.describe('Authentication System', () => {
     // section and the link into their team's pay live.
     await expect(page).toHaveURL('/dashboard');
 
-    // Check for the dashboard's welcome heading (seeded manager: 'Manager User')
-    await expect(page.locator('h1')).toContainText('Welcome, Manager User!');
+    // Check for the dashboard's welcome heading (seeded manager: 'Test Manager')
+    await expect(page.locator('h1')).toContainText('Welcome, Test Manager!');
   });
 
   test('should login as employee and access regular dashboard', async ({ page }) => {
@@ -39,6 +39,6 @@ test.describe('Authentication System', () => {
     await expect(page).toHaveURL('/dashboard');
     
     // Check for dashboard content
-    await expect(page.locator('h1')).toContainText('Welcome, Employee User!');
+    await expect(page.locator('h1')).toContainText('Welcome, Test Employee!');
   });
 });

--- a/tests/e2e/employee-management.spec.ts
+++ b/tests/e2e/employee-management.spec.ts
@@ -72,7 +72,7 @@ test.describe('Employee Management - Core Functions', () => {
       await page.waitForTimeout(1000) // Wait for search to process
       
       // Should show search results containing "Admin"
-      const employeeCards = page.locator('text=Admin User').first()
+      const employeeCards = page.locator('text=Test Admin').first()
       await expect(employeeCards).toBeVisible()
     })
 
@@ -82,9 +82,9 @@ test.describe('Employee Management - Core Functions', () => {
       await page.waitForLoadState('networkidle')
       
       // Should show employee information - use .first() to avoid strict mode
-      await expect(page.locator('text=Admin User').first()).toBeVisible()
-      await expect(page.locator('text=Employee User').first()).toBeVisible()
-      await expect(page.locator('text=Manager User').first()).toBeVisible()
+      await expect(page.locator('text=Test Admin').first()).toBeVisible()
+      await expect(page.locator('text=Test Employee').first()).toBeVisible()
+      await expect(page.locator('text=Test Manager').first()).toBeVisible()
       
       // Should have action buttons - getByRole is more reliable
       const viewButton = page.getByRole('button', { name: 'View Details' }).first()
@@ -166,7 +166,7 @@ test.describe('Employee Management - Core Functions', () => {
       await page.waitForLoadState('networkidle')
       
       // Click on employee name link using getByRole
-      const employeeLink = page.getByRole('link', { name: 'Admin User' })
+      const employeeLink = page.getByRole('link', { name: 'Test Admin' })
       
       await employeeLink.click()
       await page.waitForLoadState('networkidle')
@@ -196,7 +196,7 @@ test.describe('Employee Management - Core Functions', () => {
       expect(isOnDetailPage || isOnEmployeesPage).toBeTruthy()
       
       if (isOnDetailPage) {
-        const hasEmployeeInfo = await page.locator('text=Admin User').first().isVisible()
+        const hasEmployeeInfo = await page.locator('text=Test Admin').first().isVisible()
         expect(hasEmployeeInfo).toBeTruthy()
       }
     })
@@ -319,7 +319,7 @@ test.describe('Employee Management - Core Functions', () => {
     test('Edit employee page should render without errors for valid employee', async ({ page }) => {
       await loginAsAdmin(page)
 
-      // Navigate to edit page for employee ID 1 (Admin User)
+      // Navigate to edit page for employee ID 1 (Test Admin)
       const response = await page.goto('/admin/employees/1/edit')
 
       // Page should return 200, not 500 (regression: async params must be awaited in Next.js 15)
@@ -329,7 +329,7 @@ test.describe('Employee Management - Core Functions', () => {
       await expect(page.locator('h1')).toContainText('Edit Employee')
 
       // The employee name should be rendered (proves params.id resolved correctly, not NaN)
-      await expect(page.locator('text=Admin User').first()).toBeVisible()
+      await expect(page.locator('text=Test Admin').first()).toBeVisible()
     })
 
     test('Employee detail page should render without errors for valid employee', async ({ page }) => {
@@ -341,7 +341,7 @@ test.describe('Employee Management - Core Functions', () => {
       expect(response?.status()).toBe(200)
 
       // Should show employee name, not an error
-      await expect(page.locator('text=Admin User').first()).toBeVisible()
+      await expect(page.locator('text=Test Admin').first()).toBeVisible()
 
       // Edit link should point to the correct employee
       const editLink = page.getByRole('link', { name: 'Edit Employee' })
@@ -416,7 +416,7 @@ test.describe('Employee Management - Core Functions', () => {
       await expect(page.locator('h1')).toBeVisible()
       
       // Employee cards should be responsive - use .first() to avoid strict mode
-      const hasEmployeeCards = await page.locator('text=Admin User').first().isVisible()
+      const hasEmployeeCards = await page.locator('text=Test Admin').first().isVisible()
       const hasResponsiveLayout = await page.locator('.grid').first().isVisible()
       
       expect(hasEmployeeCards || hasResponsiveLayout).toBeTruthy()

--- a/tests/setup/auth.setup.ts
+++ b/tests/setup/auth.setup.ts
@@ -36,10 +36,10 @@ setup('authenticate as admin', async ({ page }) => {
   await page.fill('[name="email"]', testUser.email);
   await page.fill('[name="password"]', testUser.password);
   await page.click('button[type="submit"]');
-  
-  // Wait for successful login redirect
-  await page.waitForURL('/dashboard');
-  
+
+  // Admins keep their own role-specific landing
+  await page.waitForURL('/admin');
+
   // Save authentication state
   await page.context().storageState({ path: adminAuthFile });
 });

--- a/tests/utils/auth-helper.ts
+++ b/tests/utils/auth-helper.ts
@@ -33,8 +33,10 @@ export async function loginAsManager(page: Page) {
   // Click login button
   await page.click('button[type="submit"]');
   
-  // Wait for redirect to manager dashboard
-  await page.waitForURL('/manager/dashboard');
+  // Managers land on the shared /dashboard, where their own pay and the route
+  // into their team's pay live. (/manager is an orphaned stub that redirects
+  // here; only admins get a role-specific landing.)
+  await page.waitForURL('/dashboard');
 }
 
 export async function loginAsEmployee(page: Page) {

--- a/tests/utils/test-data-seeder.ts
+++ b/tests/utils/test-data-seeder.ts
@@ -59,7 +59,7 @@ export class TestDataSeeder {
   static readonly TEST_EMPLOYEES: TestEmployee[] = [
     {
       id: 1,
-      name: 'Admin User',
+      name: 'Test Admin',
       email: 'admin@test.com',
       isActive: true,
       isAdmin: true,
@@ -68,7 +68,7 @@ export class TestDataSeeder {
     },
     {
       id: 2,
-      name: 'Manager User',
+      name: 'Test Manager',
       email: 'manager@test.com',
       isActive: true,
       isAdmin: false,
@@ -78,7 +78,7 @@ export class TestDataSeeder {
     },
     {
       id: 3,
-      name: 'Employee User',
+      name: 'Test Employee',
       email: 'employee@test.com',
       isActive: true,
       isAdmin: false,


### PR DESCRIPTION
## The original bug

Ralph Barker (employee `36`, `is_mgr=1`, one direct report) could see his subordinate's payroll but never his own, despite having **844 paystubs** keyed to `paystubs.agent_id = 36`.

Every manager-scoped list query filtered on `managedEmployeeIds`, which is loaded from `manager_employees` and by definition never contains the manager themselves:

```ts
if (userContext.isManager && userContext.managedEmployeeIds?.length) {
  query = query.where('employees.id', 'in', userContext.managedEmployeeIds)  // self missing
} else if (userContext.employeeId) {
  query = query.where('employees.id', '=', userContext.employeeId)           // unreachable for managers
}
```

Perversely, a manager with **zero** reports fell through to the self branch and *did* see their own payroll — so the bug only bit managers who actually manage someone. Detail-level access already allowed self, so this was purely a list-filter gap: managers could reach their own statement by URL, they just could never find it.

**Fix:** `accessibleEmployeeIds()` (self + reports, deduped) applied at the four read-scope sites — `getPayrollSummary`'s data and count queries, `getAvailableIssueDates`, and `getAccessibleAgents`. Admin and plain-employee paths are unchanged; `managedEmployeeIds` keeps its "subordinates only" meaning everywhere else, since write-permission checks deliberately exclude self.

Ralph's payroll goes from 10 rows to **854** — his 844 plus Anna Barker's 10, and nothing else. Four active managers regain their own statements (James Nelson, Ralph Barker, Al Willis, Rebecca Payment); the fifth manager in the affected set is the seeded `Test Manager` account, which has no paystubs of its own.

## Then: making it a first-class experience

Fixing the query wasn't enough — a manager still had to dig for their own pay, and it was interleaved with their team's.

### Own vs. team separation

`PayrollFilters.scope` (`'mine' | 'team'`) narrows a payroll list to one side of an elevated user's access. The security property is that **scope can only ever remove rows**: it is intersected against the role-resolved id set, never substituted for it.

```
scopeIds = 'mine' → employeeId ? [employeeId] : []
           'team' → dedupe(managedEmployeeIds ?? [])
           else   → null                     // no narrowing
admin:     scopeIds === null → unfiltered ; else scopeIds.length ? IN scopeIds : EMPTY
manager:   base = accessibleEmployeeIds(ctx)           // self + reports
           narrowed = scopeIds ∩ base → narrowed.length ? IN narrowed : EMPTY
employee:  scopeIds === null || scopeIds.includes(self) ? `= self` : EMPTY
```

`EMPTY` short-circuits before any SQL runs — never an unbounded query, never an invalid `IN ()`. The data and count queries share one resolution so pagination can't advertise rows the list hides, and the non-admin release-date cutoff still AND-combines in every branch. `parsePayrollScope` gates the untrusted `?scope=` param; anything outside the union degrades to "no narrowing".

An **All / My pay / My team** toggle on `/payroll` drives it, shown to any elevated viewer, with "My team" appearing only for those who actually have reports.

### Dashboard

The rep home's pay hero is extracted into `PersonalPaySection` and reused on the manager/admin home **above** quick actions, so a manager's own latest statement is the first thing they see, with their team one deliberate click away at `/payroll?scope=team`. Elevated users with no statements of their own render nothing rather than an empty hero. The rep dashboard is unchanged — the extraction returns a bare fragment when untitled, preserving the parent's spacing rhythm exactly.

**Managers now land on `/dashboard` at sign-in.** They were being sent to `/manager`, a stub whose three primary cards pointed at `/manager/employees`, `/manager/payroll` and `/manager/reports` — none of which exist — and which nothing in the navigation links to. Without this, none of the above would ever have been seen. `/manager` and `/manager/dashboard` now redirect to `/dashboard`, keeping their auth guards so neither becomes an open redirect, and a `next.config.ts` rewrite that was shadowing those guards is removed.

## Fail-closed invoice agent list

`getInvoicePageResources` gated its filter on the allow-list being non-empty, with no `else`:

```ts
if (!isAdmin && isManager && managedEmployeeIds?.length) {
  agentQuery = agentQuery.where('id', 'in', managedEmployeeIds)
}
// no else — falls through unfiltered
```

A non-admin manager with zero direct reports therefore received **every** active employee (541 rows) in the invoice-creation agent picker — the guard was skipped precisely when the allow-list was empty. Both implementations now skip the query entirely and return an empty list. Scope stays direct-reports-only, not self: the write checks (`assertCanWrite`) deny a manager acting on their own agent id, so offering self would be an option that 403s on submit. Fixed in `InvoiceRepository.ts` and `InvoiceRepository.simple.ts` — the latter is what `/api/invoices` actually imports.

## Verification

- **Real data** (local prod snapshot): Ralph's `mine` (844) and `team` (10) are disjoint and their union is exactly the unscoped 854. His Apr 1 2026 statement detail loads with Net Pay \$9,566.27. A negative control for an unrelated employee still returns `null`.
- **Tests**: 468 passing, 2 failures pre-existing on `main` (`AdvanceRepository.resync` timezone assertion, `marketing/products` jest.mock hoisting). New coverage: scope narrowing across every role × scope pair including a property test that the permitted set is always a subset of the unscoped set, the release-date cutoff under scope, `parsePayrollScope` against garbage input, invoice fail-close in both implementations, and the `/manager` guards.
- **Mutation-tested**: converting the scope intersection to a substitution — the exact privilege-escalation bug the design prevents — fails the suite. An earlier revision of the tests did *not* catch this (the employee fixture had no `managedEmployeeIds` to substitute in); a fixture carrying stale reports was added to pin it.
- **Adversarial review**: two rounds. First returned NO-GO on three defects — the E2E helper still asserted the deleted `/manager/dashboard` landing (22 call sites), `?scope=mine` was a silent unescapable filter for admins with no toggle to clear it, and the mutation gap above. All fixed; second round GO with the security core re-verified.
- **Browser-verified** across all three roles: toggle visibility and filter-count per role, cold navigation to a scoped URL, clearing filters, redirects (manager → `/dashboard`, employee → `/forbidden`, signed-out → `/auth/signin`), dark mode, no console or hydration errors.
- Lint clean on all new lines; build succeeds.

## Follow-ups (not in this PR)

1. **Managers with an empty `sales_id1` can't pick themselves in the agent dropdown.** `getAccessibleAgents` keeps its pre-existing `sales_id1 != ''` guard; 2 of the 5 affected managers have an empty value.
2. **`/payroll` summary tiles are wrong for everyone.** `getPayrollAccessSummary` keys `paystubs.agent_id` off `parseInt(sales_id1)`, but `agent_id` is `employees.id` (14083/14083 rows confirm). Pre-existing; the tiles read 0 before and after.
3. **No test account can exercise impersonation** — `scripts/seed-test-accounts.ts` never sets `is_super_admin`.
4. **Partially resolved in this PR** — the e2e name assertions and the dead seeder's fixtures now match the live seeded names (`Test Admin` / `Test Manager` / `Test Employee`), fixing a welcome-heading assertion this PR had added against the wrong name. Still open: `tests/setup/auth.setup.ts` is never executed (no `setup` project in `playwright.config.ts`), and the employee-ID-1 tests in `employee-management.spec.ts` assume the dead seeder's fixed IDs (id 1 is a real employee in the snapshot).
5. **Page guards redirect to a bare `/auth/signin` with no `callbackUrl`**, so users aren't returned to what they asked for. App-wide, pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLarE8f9SBCtxLGi9qURRc
