### PR TITLE
fix: payroll summary tiles and vendor filter keyed off the wrong column

### DIFF
--- a/src/lib/auth/__tests__/payroll-access.test.ts
+++ b/src/lib/auth/__tests__/payroll-access.test.ts
@@ -9,12 +9,17 @@ jest.mock('@/lib/database/client', () => {
   mockChain = {
     selectFrom: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     execute: jest.fn().mockResolvedValue([]),
     executeTakeFirst: jest.fn().mockResolvedValue(null),
   }
-  return { db: mockChain }
+  const fn = Object.assign(jest.fn().mockReturnValue('date_expr'), {
+    count: jest.fn().mockReturnValue({ as: jest.fn().mockReturnValue('count_expr') }),
+  })
+  return { db: Object.assign(mockChain, { fn }) }
 })
 
 // getAccessibleIssueDates delegates to the repository; stub it out so this file
@@ -25,7 +30,12 @@ jest.mock('@/lib/repositories/PayrollRepository', () => ({
   })),
 }))
 
-import { getAccessibleAgents } from '@/lib/auth/payroll-access'
+import {
+  getAccessibleAgents,
+  getAccessibleVendors,
+  getPayrollAccessSummary,
+  validatePayrollAccess,
+} from '@/lib/auth/payroll-access'
 
 const SELF = 36
 const SUBORDINATE = 1184
@@ -99,5 +109,100 @@ describe('getAccessibleAgents', () => {
 
     expect(result).toEqual([])
     expect(idFilters()).toHaveLength(0)
+  })
+})
+
+// paystubs.agent_id stores employees.id. `sales_id1` is an unrelated sales code
+// (usually 'CMPxxxx', sometimes a number that collides with another employee's
+// primary key), so keying paystub lookups off parseInt(sales_id1) either drops
+// the agent or reads a stranger's data. These fixtures encode both failure
+// modes: reverting to parseInt(sales_id1) yields [184] instead of [36, 18].
+const AGENT_FIXTURES = [
+  { id: 36, name: 'Ralph Barker', sales_id1: '184', email: '', is_active: 1 },
+  { id: 18, name: 'James Nelson', sales_id1: 'CMP9410', email: '', is_active: 1 },
+]
+
+describe('getAccessibleVendors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockChain.execute.mockResolvedValue([])
+  })
+
+  it('keys the paystub join off employees.id, not sales_id1', async () => {
+    mockChain.execute.mockResolvedValueOnce(AGENT_FIXTURES)
+
+    await getAccessibleVendors(managerCtx)
+
+    const agentFilters = mockChain.where.mock.calls.filter(
+      (call: unknown[]) => call[0] === 'paystubs.agent_id'
+    )
+    expect(agentFilters).toEqual([['paystubs.agent_id', 'in', [36, 18]]])
+  })
+
+  it('skips the vendor query entirely when no agents are accessible', async () => {
+    const result = await getAccessibleVendors(orphanManagerCtx)
+
+    expect(result).toEqual([])
+    expect(mockChain.selectFrom).not.toHaveBeenCalledWith('vendors')
+  })
+})
+
+describe('getPayrollAccessSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockChain.execute.mockResolvedValue([])
+    mockChain.executeTakeFirst.mockResolvedValue(null)
+  })
+
+  it('counts paystubs by employees.id, not sales_id1', async () => {
+    mockChain.execute
+      .mockResolvedValueOnce(AGENT_FIXTURES) // getAccessibleAgents (direct)
+      .mockResolvedValueOnce(AGENT_FIXTURES) // getAccessibleAgents inside getAccessibleVendors
+      .mockResolvedValueOnce([{ id: 1, name: 'Palmco', is_active: 1 }]) // vendors
+    mockChain.executeTakeFirst.mockResolvedValueOnce({ count: 1170 })
+
+    const summary = await getPayrollAccessSummary(managerCtx)
+
+    const countFilters = mockChain.where.mock.calls.filter(
+      (call: unknown[]) => call[0] === 'agent_id'
+    )
+    expect(countFilters).toEqual([['agent_id', 'in', [36, 18]]])
+    expect(summary).toEqual({
+      accessibleAgents: 2,
+      accessibleVendors: 1,
+      accessibleIssueDates: 0,
+      totalPaystubs: 1170,
+    })
+  })
+
+  it('reports zero paystubs without querying when no agents are accessible', async () => {
+    const summary = await getPayrollAccessSummary(orphanManagerCtx)
+
+    expect(summary.totalPaystubs).toBe(0)
+    expect(mockChain.selectFrom).not.toHaveBeenCalledWith('paystubs')
+  })
+})
+
+describe('validatePayrollAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockChain.executeTakeFirst.mockResolvedValue(null)
+  })
+
+  it('checks paystub existence by employees.id, not sales_id1', async () => {
+    mockChain.executeTakeFirst.mockResolvedValueOnce({ id: 99 })
+
+    const allowed = await validatePayrollAccess(SELF, 1, '2026-04-01', managerCtx)
+
+    expect(allowed).toBe(true)
+    expect(mockChain.where).toHaveBeenCalledWith('agent_id', '=', SELF)
+    expect(mockChain.selectFrom).not.toHaveBeenCalledWith('employees')
+  })
+
+  it('denies before querying when the employee is outside the caller scope', async () => {
+    const allowed = await validatePayrollAccess(9999, 1, '2026-04-01', managerCtx)
+
+    expect(allowed).toBe(false)
+    expect(mockChain.selectFrom).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/auth/payroll-access.ts
+++ b/src/lib/auth/payroll-access.ts
@@ -134,9 +134,9 @@ export async function getAccessibleVendors(
   name: string
   is_active: number
 }>> {
-  // Get accessible agent IDs first
+  // paystubs.agent_id stores employees.id, not sales_id1
   const agents = await getAccessibleAgents(userContext)
-  const agentIds = agents.map(agent => parseInt(agent.sales_id1)).filter(id => !isNaN(id))
+  const agentIds = agents.map(agent => agent.id)
 
   if (agentIds.length === 0) {
     return []
@@ -180,20 +180,12 @@ export async function validatePayrollAccess(
     return false
   }
 
-  // Additional validation: check if the combination exists
-  const employee = await db
-    .selectFrom('employees')
-    .select('sales_id1')
-    .where('id', '=', employeeId)
-    .executeTakeFirst()
-
-  if (!employee?.sales_id1) return false
-
   // Check if paystub exists for this combination
+  // (paystubs.agent_id stores employees.id, not sales_id1)
   const paystub = await db
     .selectFrom('paystubs')
     .select('id')
-    .where('agent_id', '=', parseInt(employee.sales_id1))
+    .where('agent_id', '=', employeeId)
     .where('vendor_id', '=', vendorId)
     .where(db.fn('DATE', ['issue_date']), '=', issueDate)
     .executeTakeFirst()
@@ -216,8 +208,8 @@ export async function getPayrollAccessSummary(
   const vendors = await getAccessibleVendors(userContext)
   const issueDates = await getAccessibleIssueDates(userContext)
 
-  // Count total paystubs accessible to user
-  const agentIds = agents.map(agent => parseInt(agent.sales_id1)).filter(id => !isNaN(id))
+  // Count total paystubs accessible to user (paystubs.agent_id stores employees.id)
+  const agentIds = agents.map(agent => agent.id)
   
   let totalPaystubs = 0
   if (agentIds.length > 0) {


### PR DESCRIPTION
## The bug (follow-up #2 from PR #91)

`paystubs.agent_id` stores `employees.id` — all 14,083 rows join on it, and `PayrollRepository.getPayrollSummary` already joins `paystubs.agent_id = employees.id`. But `getAccessibleVendors` and `getPayrollAccessSummary` built their agent id set from `parseInt(sales_id1)`:

- 494 of 541 active employees have a non-numeric `sales_id1` (`CMPxxxx`), so `parseInt` → `NaN` dropped nearly everyone.
- The few numeric values collide with **unrelated employees' primary keys** — e.g. a manager's tile showed a stranger's paystub count (a report's `sales_id1 = '216'` pulled in employee 216's 107 paystubs).

Net effect on `/payroll`: the Vendor filter dropdown was **empty for every user including admins** (all vendor ids reachable through the wrong id set were inactive), and the access-summary tiles were nonsense (admin: 121 of 14,083 paystubs, 0 of 5 vendors).

## The fix

Key both sites off `agent.id`. `validatePayrollAccess` (currently uncalled — kept for future use) had the same pattern and now checks paystub existence by `employees.id` directly, dropping its intermediate `sales_id1` lookup.

Tile totals stay scoped to `getAccessibleAgents`' pre-existing `is_active` and `sales_id1 != ''` guards — that's why admin reads 8,455 rather than 14,083. Lifting the empty-`sales_id1` guard is follow-up #1 on PR #91 and intentionally not bundled here so this diff stays a pure column-keying fix.

## Tests

New coverage in `payroll-access.test.ts` pins the keying with fixtures encoding both failure modes (a numeric `sales_id1` colliding with another employee's id, and a `CMPxxxx` value): reverting to `parseInt(sales_id1)` yields `[184]` instead of `[36, 18]` and fails. Also covers the empty-agent short-circuits and `validatePayrollAccess`'s scope-check-before-query behavior. 13/13 in the suite; full run 474 passing with the same 2 pre-existing failures as `main`.

## Browser-verified (prod snapshot, admin)

- Tiles: **506 agents / 5 vendors / 470 issue dates / 8,455 paystubs** — each matches an independent SQL prediction exactly.
- Vendor dropdown lists the 5 vendors with reachable paystub data (was empty).
- Selecting DSI narrows the list to 17 grouped entries — exactly the SQL-predicted grouped count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLarE8f9SBCtxLGi9qURRc