### PR TITLE
Phase 1 pre-migration hardening: email normalization, date-range filters, safe JSON parsing

### DIFF
--- a/docs/postgres-migration-phase-1.md
+++ b/docs/postgres-migration-phase-1.md
@@ -1,0 +1,135 @@
+# Phase 1 — Pre-Migration Hardening (ships on MySQL, valuable regardless of migration)
+
+**Parent plan:** `docs/postgres-migration-plan.md`
+**Branch:** `feat/pg-migration-phase1`
+**Principle:** every item here is a real bug fix or data-quality audit on the *current* MySQL stack. Behavior on MySQL must be unchanged or strictly improved; nothing in Phase 1 depends on Postgres happening.
+
+---
+
+## Work items
+
+### A. Finish the email-normalization rollout (code)
+
+`src/lib/utils/email.ts` already exports a normalize helper (`trim().toLowerCase()`), applied in 3 of 6 email-lookup sites. Finish the job:
+
+| Site | Today | Change |
+|---|---|---|
+| `src/lib/auth/config.ts:25` (NextAuth `authorize`) | `.where('email', '=', credentials.email)` — raw | normalize input before lookup |
+| `src/app/api/auth/reset-password/route.ts:38` | `.where('email', '=', payload.email)` — raw (from JWT) | normalize |
+| `src/lib/repositories/EmployeeRepository.ts:1185` | `.where('email', '=', email)` — raw | normalize |
+
+Already correct (do not touch): `EmployeeRepository.ts:963`, `:983`.
+
+Amended during implementation:
+
+- `request-reset/route.ts:25` was listed here as "already correct", but it held an inline
+  `email.toLowerCase()` — which the acceptance criterion below rules out and which misses the
+  trim. Converted to `normalizeEmail(email)`. Behaviour delta on MySQL today: a submitted
+  address padded with leading whitespace (or a tab/newline — PAD SPACE only ignores *trailing*
+  spaces) now resolves to the user row instead of silently falling into the anti-enumeration
+  no-op. Direction is benign — trimming can only widen matching to the correct row, and the
+  snapshot has zero leading-whitespace stored emails, so no reset can be redirected to a
+  different account.
+- `src/app/api/employees/[id]/create-user/route.ts` — a 4th raw email-equality site the table
+  above missed (found by the mandated grep). Normalised, and the value is hoisted so the
+  existing-login *probe*, the `users` INSERT and the welcome-email recipient all bind the same
+  canonical string; probing one string while writing another would, under Postgres, miss a
+  mixed-case login and then trip `users_email_unique`.
+- `EmployeeRepository.softDeleteEmployee` — the parked value is now built from
+  `normalizeEmail(user.email)` so the collision guard at `:1185` probes exactly what the
+  UPDATE writes. Consequence: a delete → restore round-trip lowercases that login's stored
+  address (a no-op for authentication in either engine, since every lookup normalises).
+
+On MySQL's `unicode_ci` collation this is a behavioral no-op for case (safe to ship); it *does* newly trim whitespace — that's a strict improvement. Under Postgres later, it becomes load-bearing for login.
+
+**Tests:** unit coverage that each path normalizes (mixed-case + padded input reaches the query lowercased/trimmed). Follow existing test patterns in `src/**/__tests__/`.
+
+**Acceptance:** all three sites use the shared helper (no inline `.toLowerCase()` copies); no other raw email-equality lookups remain (verify by grep, not just the list above); existing tests still pass.
+
+### B. Email case-collision data audit (read-only, informs a later data migration)
+
+Against the **local prod snapshot** (`choice-mysql-dev` container — never prod):
+
+1. Count emails containing uppercase, in `users` and `employees` (every table with an email column — discover via `information_schema`).
+2. List collision groups: distinct emails that collapse to the same `lower(email)` within a table with a unique/lookup-relevant email column (include row ids, `is_active`, `deleted_at`).
+3. Note whitespace-padded emails.
+
+**Output:** a report (JSON/markdown) checked into nothing — surfaced in the run summary. **Decision rule:** if zero collisions → a simple `UPDATE … SET email = lower(trim(email))` migration can be authored later (via `bun run db:migrate` ledger — never hand-applied to prod). If collisions exist → each group needs a human decision (accounts may be distinct people); do NOT auto-dedupe.
+
+### C. `sales_id1/2/3` case-variance audit (read-only)
+
+Same snapshot DB. `sales_id1/2/3` are hand-entered varchars used for payroll authorization (`src/lib/auth/payroll-access.ts:59`) — under Postgres, a case mismatch silently changes payroll visibility.
+
+1. Collect all non-empty `sales_id1/2/3` values across `employees`.
+2. Report values that collide case-insensitively but differ case-sensitively (and where they're referenced, e.g. `invoices.agentid`/sales linkage as applicable).
+3. Report leading/trailing whitespace variants.
+
+**Output:** report only. Zero variance ⇒ Phase 2 needs no special handling. Any variance ⇒ plan a normalization pass + decide canonical casing before Phase 2.
+
+### D. Rewrite `fn('DATE')` filters in InvoiceAuditRepository as range predicates (code)
+
+> **Premise corrected during implementation.** This item was originally specced as fixing a
+> "live bug": the audit claimed `.where(({eb}) => eb.fn('DATE', [...]), '>=', fromDate)` passes
+> a callback where Kysely expects an expression and silently drops the filter. Both the
+> implementer and the adversarial reviewer independently disproved this against the repo's real
+> Kysely 0.28 + `MysqlQueryCompiler`: the 3-arg `where(factory, op, rhs)` form compiles to the
+> **same correct SQL** as the canonical form (re-verified in the main session with a standalone
+> compile probe). There was no live bug, so the originally demanded "test that fails on the old
+> code" is unsatisfiable and was waived.
+
+The rewrite still shipped, as an improvement rather than a bugfix: `getAuditSummary`'s
+`dateFrom`/`dateTo` filters and `recentChanges`' 30-day filter now use half-open range
+predicates on the raw `ia.changed_at` column (`col >= from AND col < to+1day`) instead of
+`DATE(col)` — sargable, Postgres-portable, plus guards for invalid date input (previously an
+`Invalid Date` string reached the SQL layer). The four remaining `fn('DATE', ['issue_date'])`
+sites in `InvoiceRepository.ts` (`getInvoiceDetail`) compile correctly and stay as-is —
+**Phase 2 scope**, per this doc's own rule about working `fn('DATE')` usages.
+
+**Tests:** SQL-compilation tests pin the emitted predicates and bound values
+(timezone-independent — the first version of these assertions was itself caught off-by-one
+under UTC+ runners by the adversarial review).
+
+### E. Defensive JSON parsing on paystub + marketing paths (code)
+
+`InvoiceRepository.ts:348` already does it right: `typeof v === 'string' ? JSON.parse(v) : v`. Apply the same both-ways guard to:
+
+- `src/lib/repositories/PayrollRepository.ts:674` — `JSON.parse(sale.custom_fields)` on the paystub sales path (throws on non-string / malformed today; throws on auto-parsed objects under pg later). Malformed JSON should degrade gracefully (log + empty object), not take down paystub rendering.
+- `src/lib/repositories/ProductMarketingRepository.ts:82` — `JSON.parse(row.feature_list)`, same treatment.
+
+Extract a small shared helper rather than a third inline copy. **Tests:** string input, already-parsed object input, null, malformed JSON.
+
+Amended during implementation: this item originally said malformed JSON on the paystub path
+should fall back to an *empty object*. The implementation falls back to `undefined` instead,
+matching the existing absent-`custom_fields` branch at the same call site — so malformed and
+missing custom fields render identically, rather than malformed producing a truthy `{}` that
+absent never produces. Accepted as the better behavior. Known minor gap (accepted): the
+`ProductMarketingRepository` call site has no test that exercises `getMarketingProducts()`
+end-to-end; the helper itself is fully unit-tested.
+
+---
+
+## Execution model
+
+1. **Implementation:** one subagent per code item (A, D, E) working on disjoint files on this branch; a separate read-only audit subagent for B+C against the local snapshot container. No commits by agents.
+2. **Adversarial review:** an independent reviewer per code item, prompted to *refute* the change: MySQL behavior regressions, missed sites, security implications (A touches the auth path), weak tests. Confirmed findings loop back to a fix pass.
+3. **Verification (main session):** `bun lint`, full `bun test`, build; E2E auth specs if touched surface warrants; human-readable diff review before any commit.
+4. **Rollout:** single PR to `main`. The B/C audit results are attached to the PR/summary, with the follow-up data-migration decision recorded here:
+
+## Audit results & decisions (run 2026-08-07, local prod snapshot `choice-mysql-dev`)
+
+- [x] **Email audit: CLEAN.** 6 tables with email-like columns checked via `information_schema`
+  (`employees`, `users`, `email_delivery_events`, `job_applications.applicant_email`,
+  `password_resets`, `subscribers`). 10 `employees` + 9 `users` rows contain uppercase; **zero
+  case-collision groups** (no two distinct emails collapse to the same `lower(trim(email))` in
+  any table); **zero** whitespace-padded emails. Note: `employees` has many *exact*-duplicate
+  emails across ids (e.g. one address on 13 rows, mostly soft-deleted) — pre-existing business
+  data, unaffected by lowercasing.
+- [x] **sales_id audit: CLEAN.** 1,078 distinct non-empty values across `sales_id1/2/3`; zero
+  case-insensitive collisions, zero whitespace variants. Cross-reference confirmed
+  `invoices.agentid` is an **INT FK to `employees.id`** (1089/1090 join match), not a string
+  match against sales_ids — so there is no invoices↔sales_id case-mismatch surface. The only
+  string-comparison path is `payroll-access.ts` `canAccessAgent()`, currently collision-free.
+- [x] **Data-normalization migration (014): GO.** A `UPDATE … SET email = lower(trim(email))`
+  pass (users + employees) is safe — no collisions to adjudicate. Author it as migration 014
+  via the `bun run db:migrate` ledger (never hand-applied to prod). Scheduled alongside or
+  before Phase 2; not required for this PR since MySQL lookups are collation-insensitive today.

--- a/docs/postgres-migration-plan.md
+++ b/docs/postgres-migration-plan.md
@@ -1,0 +1,107 @@
+# Postgres Migration Plan — MariaDB (DO droplet) → Neon (Vercel Marketplace)
+
+**Status:** Approved direction, Phase 1 in progress
+**Decision date:** 2026-08-07
+**Research basis:** vendor facts verified against live sources 2026-08-07; codebase audit of this repo same day. Line numbers below are as of commit `49227f5` — re-verify before acting on them later.
+
+---
+
+## 1. Decision summary
+
+Migrate the production database from self-managed MariaDB 10.6 (Docker on DigitalOcean droplet `snowy-surf`, NYC1) to **Neon Postgres via the Vercel Marketplace native integration**, provisioned in `aws-us-east-1` (same metro as Vercel `iad1`).
+
+**Why move at all** (it is *not* latency — NYC1↔iad1 is ~5–10 ms, fine):
+
+- The 2026-08-07 disk-full outage proved the operational risk: a 3-years-uptime, unmanaged Docker MariaDB with no automated in-DB backups, no failover, and no monitoring took the homepage down while health checks stayed green.
+- The old Laravel stack on the droplet is dead traffic-wise (15 nginx hits/7 days, all uptime pings and bot scans). The Vercel app is the DB's only real consumer — nothing gets stranded by moving it.
+- Decommissioning the droplet after cutover ends the disk-full incident class permanently and likely makes the move cost-negative.
+
+**Why Neon specifically:**
+
+| Factor | Neon |
+|---|---|
+| Region | aws-us-east-1 (N. Virginia — same metro as Vercel iad1) |
+| PITR | Included in base plans: 7-day (Launch), 30-day (Scale). Not an add-on. |
+| Pooling | Built-in PgBouncer (`-pooler` endpoint) — replaces our `connectionLimit: 1` serverless hack |
+| Vercel integration | Native marketplace: unified billing, env-var injection, **automatic copy-on-write DB branch per preview deployment** |
+| Pricing (verified 2026-08) | Launch tier is pure usage-based, no monthly minimum; $0.35/GB-mo storage, $0.106/CU-hr compute, scale-to-zero. Our ~6 GB ≈ low single digits $/mo. |
+| Vendor risk | Databricks-owned since May 2025 (~$1B acquisition) |
+
+**Rejected alternatives** (facts verified 2026-08-07):
+
+- **Supabase** — Pro $25/mo buys auth/realtime/storage we already have (NextAuth, Vercel Blob); true PITR is a **$100/mo add-on** → ~$130/mo for what Neon includes.
+- **Prisma Postgres** — novel unikernel infra, ~18 months GA, per-operation billing, Prisma-ORM-centric (we're on Kysely), no verifiable PITR story. Wrong risk profile for payroll.
+- **PlanetScale** — Vitess/MySQL floor is $39/mo for sharding we'll never use (no free tier since Apr 2024). Their Postgres product (GA Sep 2025, $5–15/mo, Metal from $50) is credible but inherits the same migration cost as Neon with weaker Vercel integration.
+- **AWS via Vercel Marketplace** — covers Aurora PostgreSQL, DynamoDB, DSQL only; **not** RDS MySQL/MariaDB. Plain RDS (~$14/mo db.t4g.micro, supports MariaDB) means hand-managed AWS networking/credentials — the ops burden we're shedding.
+- **DigitalOcean Managed MySQL** — the honest zero-code-risk fallback: $15/mo single node / $60/mo HA, true 7-day PITR, NYC region. If we ever abandon the Postgres migration, this is the move. Its only costs are staying off the Vercel platform and single-node non-HA at the entry price.
+
+Sources: neon.com/pricing · neon.com/docs/guides/vercel-managed-integration · neon.com/docs/introduction/regions · planetscale.com/pricing · planetscale.com/changelog/postgres-ga · vercel.com/blog/aws-databases-are-now-live-on-the-vercel-marketplace-and-v0 · docs.digitalocean.com/products/databases/mysql/details/pricing · pgloader.readthedocs.io/en/latest/ref/mysql.html · kysely.dev/docs/dialects
+
+---
+
+## 2. Codebase audit — migration surface (audited 2026-08-07)
+
+Scale: 22 repository files / ~9,400 LOC, 192 `.execute(` sites, 53 tables in `types.ts`, 15 raw-MySQL migration files. The Kysely abstraction held up: **1** raw `sql` tag and **3** MySQL-only builder calls in all of the repositories. The cost is concentrated in silent behavioral differences, not SQL rewriting.
+
+### 2.1 Mechanical (find/replace, compiler-verifiable, ~1 day)
+
+| Item | Sites | Where |
+|---|---|---|
+| `MysqlDialect`/`createPool` → `PostgresDialect` | 1 | `src/lib/database/client.ts` — delete `getDatabaseConfig()` and mysql2-only pool options (`supportBigNumbers`, `bigNumberStrings`, `dateStrings`) |
+| `'like'` → `'ilike'` (restores today's CI search behavior) | 25 | EmployeeRepository, InvoiceAuditRepository, SubscriberRepository, DocumentRepository, VendorRepository, `api/users/search` |
+| `serverExternalPackages` mysql2 → pg | 1 | `next.config.ts:31` |
+| Swap `mysql2` → `pg` / `@neondatabase/serverless` | 1 | `package.json` |
+| `.env*`/docs URL scheme + `CLAUDE.md:249` ("no RETURNING") rule inversion | ~7 files | |
+| `docker-compose.dev.yml` → postgres image | 1 | |
+| Regenerate `types.ts` (kysely-codegen switches introspector on URL scheme) | 1 | Also fixes `feature_flags`/`feature_flag_overrides` currently missing from `DB` |
+| Drop 2 unused FULLTEXT indexes | — | No `MATCH…AGAINST` anywhere in app code |
+
+### 2.2 Needs care (silent if wrong, ~1–2 weeks)
+
+- **`insertId` → `.returning('id')` — 26 non-test sites.** Postgres never populates `InsertResult.insertId`; `Number(undefined)` is `NaN`. Sites span EmployeeRepository (×4), PayrollRepository:1061 (deletion audit), InvoiceRepository:482, InvoiceRepository.simple:202/239/280, AdvanceRepository:119, ExpenseAuditRepository:67, InvoiceAuditRepository:215, ScheduledExpenseRepository:351, VendorRepository:135, VendorFieldRepository:209, DocumentRepository:213, ProductRepository:203/246, SubscriberRepository:208, BillingRepository:141/201, ImpersonationRepository:69, FeatureFlagRepository:149, JobApplicationRepository:79 (degrades to `0` silently — no throw), `api/employees/[id]/create-user/route.ts:141`, plus `scripts/seed-test-accounts.ts`.
+- **tinyint-as-boolean — ~90 sites across three inconsistent conventions.** 26 `tinyint(1)` columns typed as `number` today. 33 strict `=== 1` reads (incl. all auth flags), 32 `? 1 : 0` writes, 25 `.where(flag, '=', 1|0)` filters, plus 21 `Boolean(...)` sites that survive unchanged. **Mitigation chosen: import tinyint as `smallint` (not boolean) so all 90 sites work unchanged; convert to real boolean as a separate later project.**
+- **`onDuplicateKeyUpdate` → `onConflict` — 3 sites** (ProductMarketingRepository:138, FeatureFlagRepository:194, InvoiceRepository.simple:304 — the last is inside the payroll transaction). Not mechanical: `ON CONFLICT` requires naming the exact unique constraint per site.
+- **`fn('DATE', [...])` — 72 sites** (34 in PayrollRepository). Usually works in pg via cast-function syntax but is index-hostile in both engines; convert to half-open range predicates opportunistically.
+- **`ON UPDATE CURRENT_TIMESTAMP` — 9 prod tables.** Postgres needs `BEFORE UPDATE` triggers or a verified app-side `updated_at` write on every `.updateTable()` (currently inconsistent).
+- **JSON columns — keep as `text` in pg.** 3 `JSON.parse` sites; `PayrollRepository.ts:674` (paystub sales path) and `ProductMarketingRepository.ts:82` are undefended and would throw on auto-parsed `jsonb`. (Fixed in Phase 1.)
+- **ENUM columns (10) → `text` + `CHECK`**, so the string-union types survive verbatim and we avoid `ALTER TYPE … ADD VALUE`'s no-transaction restriction.
+- **NULLS ordering flips** on ASC for nullable sort keys (55 `orderBy` sites — per-query eyeball, only nullable keys matter).
+- **`db.fn.count<number>()` type lie — 13 sites**: pg returns `int8` as string; `count > 0` silently becomes string comparison.
+- **Migration runner**: `scripts/run-migrations.ts` is raw-mysql2 with a hand-rolled `DELIMITER` parser. Don't port the 15 MySQL DDL files — generate a fresh Postgres baseline and start a new ledger.
+
+### 2.3 Risky (dedicated plan + staged rollout)
+
+1. **Auth/login.** `src/lib/auth/config.ts` combines both silent-failure classes: line 25 case-sensitive email lookup (MySQL is `utf8mb3_unicode_ci` today — case/accent-insensitive everywhere), lines 76–79 `is_admin === 1`-style flag reads. Password reset gates on the same pattern, so the natural user workaround breaks in the same instant. Prerequisites: finish `normalizeEmail` rollout + one-time `lower(email)` data pass **with case-collision dedupe** (two rows differing only by case are legal under today's CI unique index). Complication: `users.id` is a non-unique int and one employee can resolve to several user rows (see CLAUDE.md) — case-collapsing can merge identity sets.
+2. **Payroll money correctness.** Decimal→string→`parseFloat` convention ports cleanly (pg also returns `numeric` as string). Risks are in the machinery: `insertId` NaN inside the payroll transaction (InvoiceRepository.simple:280 writes it as an FK) and the deletion-audit path (PayrollRepository:1061); the undefended `JSON.parse` at PayrollRepository:674; and 18 `toISOString().split('T')[0]` grouping-key builds with an existing local-midnight/UTC hazard that driver-timezone changes will shift, not fix. **The proof gate: diff per-agent/vendor/issue-date SUM(amount) for paystubs, sales, overrides, expenses, and advances between both databases, to the cent, before cutover** (§4).
+3. **`sales_id1/2/3` payroll authorization.** `src/lib/auth/payroll-access.ts:59` matches hand-entered varchar sales IDs; under pg a case mismatch silently changes *whose payroll someone can see*. Audit values for case variance pre-cutover (Phase 1).
+4. **Vendor-name uniqueness divergence.** Migration 008's `UNIQUE (name)` is case-insensitive today, case-sensitive under pg, while `VendorRepository.isNameAvailable` stays CI — app and DB will disagree. Restore with `CREATE UNIQUE INDEX ON vendors (lower(name))`.
+5. **Dump conversion.** 34 tables `utf8mb3_unicode_ci`, 10 `utf8mb4`, **2 `latin1` (need explicit transcoding or mojibake)**; 56 `unsigned` columns need range checks; pgloader cast rules: `tinyint → smallint drop typemod` (NOT the default tinyint(1)→boolean), zero-dates→NULL, enum→text.
+
+---
+
+## 3. Phased plan
+
+- **Phase 0 — backups. DONE (already covered):** nightly full-droplet backups exist on the DO side. Local dump copies also exist in `~/db-backups/` (see memory/db-backup docs).
+- **Phase 1 — pre-migration hardening on MySQL (~2–3 days).** Bug fixes valuable today that shrink the Postgres blast radius. Detailed in `docs/postgres-migration-phase-1.md`. Ships to prod on MySQL, independently of any migration decision.
+- **Phase 2 — provision + port (~1 week).** `vercel integration add neon` (region `aws-us-east-1`). pgloader import with the cast rules above. Code: dialect swap, regenerate types, 26 `insertId` rewrites, 3 `onConflict` conversions, 25 `ilike` flips, `lower(name)` vendor index, `updated_at` trigger-or-audit, fresh pg migration baseline + runner.
+- **Phase 3 — verify (~3–4 days).** Full unit + Playwright suites against a Neon branch; auth smoke for all three seeded roles incl. mixed-case email sign-in; the payroll reconciliation diff (§4); `sales_id` scope checks per role.
+- **Phase 4 — cutover (an evening).** Freeze writes (low traffic), final pgloader run (full reload is minutes at this size), flip `DATABASE_URL` in Vercel env, monitor. Droplet becomes read-only fallback for 30 days, then decommission.
+- **Post-migration cleanup (unscheduled):** smallint→boolean flag conversion, `citext`/lower() email index, fn('DATE')→range predicates, count-as-string typing.
+
+## 4. Cutover proof gate — payroll reconciliation
+
+Run on **both** databases with identical frozen data; every row must match to the cent:
+
+```sql
+SELECT agent_id, vendor_id, issue_date, COUNT(*), SUM(amount) FROM paystubs   GROUP BY 1,2,3;
+SELECT agentid,  vendor,    issue_date, COUNT(*), SUM(amount) FROM invoices   GROUP BY 1,2,3;
+SELECT -- same shape for overrides, expenses, advances
+```
+
+Plus: row counts for all tables; `SELECT lower(email), COUNT(*) FROM users GROUP BY 1 HAVING COUNT(*) > 1` must return the same (ideally empty) set on both.
+
+## 5. Open decisions
+
+- Neon driver: standard `pg` Pool via pooled endpoint vs `@neondatabase/serverless`. Leaning `pg` + PgBouncer endpoint — least code change, well-trodden with Kysely `PostgresDialect`.
+- Preview-deployment DB branching: enabled by the integration by default; decide whether E2E in CI should use a branch per PR.
+- What to do with the droplet's Laravel containers at decommission time (archive an image? just snapshot the droplet and destroy?).

--- a/src/app/api/auth/__tests__/request-reset.email-normalization.test.ts
+++ b/src/app/api/auth/__tests__/request-reset.email-normalization.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ *
+ * `POST /api/auth/request-reset` already lowercased its input; it now goes
+ * through the shared `normalizeEmail` helper, which additionally trims. These
+ * tests pin both halves so the site cannot regress to a raw lookup or drift
+ * away from the helper.
+ *
+ * The compile-only driver returns no rows, so every request here takes the
+ * anti-enumeration success path — the bound parameter is the behaviour.
+ */
+/* eslint-disable no-var */
+var capturedQueries: { sql: string; parameters: readonly unknown[] }[]
+/* eslint-enable no-var */
+
+jest.mock('@/lib/database/client', () => {
+  const {
+    Kysely,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+    DummyDriver,
+  } = jest.requireActual('kysely')
+
+  capturedQueries = []
+
+  return {
+    db: new Kysely({
+      dialect: {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => new DummyDriver(),
+        createIntrospector: (kysely: never) => new MysqlIntrospector(kysely),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      },
+      log: (event: { level: string; query: { sql: string; parameters: readonly unknown[] } }) => {
+        if (event.level === 'query') {
+          capturedQueries.push({ sql: event.query.sql, parameters: event.query.parameters })
+        }
+      },
+    }),
+  }
+})
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}))
+
+const mockSend = jest.fn().mockResolvedValue({ id: 'email_1' })
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({ emails: { send: mockSend } })),
+}))
+
+jest.mock('@react-email/render', () => ({
+  render: jest.fn().mockReturnValue('<html></html>'),
+}))
+
+import { POST } from '../request-reset/route'
+
+function post(email: unknown) {
+  return POST(
+    new Request('http://localhost:3000/api/auth/request-reset', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+  )
+}
+
+describe('POST /api/auth/request-reset — email normalisation', () => {
+  beforeEach(() => {
+    capturedQueries.length = 0
+    mockSend.mockClear()
+  })
+
+  it('lowercases the submitted address before the users lookup', async () => {
+    await post('Mixed.Case@Example.COM')
+
+    const lookup = capturedQueries[0]
+    expect(lookup.sql).toContain('from `users`')
+    expect(lookup.sql).toContain('`email` = ?')
+    expect(lookup.parameters[0]).toBe('mixed.case@example.com')
+  })
+
+  it('trims surrounding whitespace before the users lookup', async () => {
+    await post('  employee@test.com \n')
+
+    expect(capturedQueries[0].parameters[0]).toBe('employee@test.com')
+  })
+
+  it('handles mixed case and padding together', async () => {
+    await post('\t ADMIN@Test.Com  ')
+
+    expect(capturedQueries[0].parameters[0]).toBe('admin@test.com')
+  })
+
+  it('keeps the anti-enumeration response for an unknown address', async () => {
+    const res = await post('Nobody@Example.com')
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.message).toContain('If an account exists')
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing address before any query runs', async () => {
+    const res = await post(undefined)
+
+    expect(res.status).toBe(400)
+    expect(capturedQueries).toHaveLength(0)
+  })
+})

--- a/src/app/api/auth/__tests__/reset-password.email-normalization.test.ts
+++ b/src/app/api/auth/__tests__/reset-password.email-normalization.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ *
+ * `POST /api/auth/reset-password` re-verifies the account named in the reset
+ * JWT. The address inside that token is whatever was stored on the `users` row
+ * when the token was minted, so the lookup must normalise it rather than trust
+ * its casing/padding.
+ *
+ * Asserted on the bound parameter: the compile-only driver returns no rows, so
+ * the response is a 404 in every case here — the parameter is the behaviour.
+ */
+/* eslint-disable no-var */
+var capturedQueries: { sql: string; parameters: readonly unknown[] }[]
+/* eslint-enable no-var */
+
+jest.mock('@/lib/database/client', () => {
+  const {
+    Kysely,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+    DummyDriver,
+  } = jest.requireActual('kysely')
+
+  capturedQueries = []
+
+  return {
+    db: new Kysely({
+      dialect: {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => new DummyDriver(),
+        createIntrospector: (kysely: never) => new MysqlIntrospector(kysely),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      },
+      log: (event: { level: string; query: { sql: string; parameters: readonly unknown[] } }) => {
+        if (event.level === 'query') {
+          capturedQueries.push({ sql: event.query.sql, parameters: event.query.parameters })
+        }
+      },
+    }),
+  }
+})
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}))
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn().mockResolvedValue('$2a$10$hashedpassword'),
+  compare: jest.fn().mockResolvedValue(true),
+}))
+
+import { POST } from '../reset-password/route'
+import { generatePasswordResetToken } from '@/lib/auth/password-reset'
+
+function makeRequest(body: object) {
+  return new Request('http://localhost:3000/api/auth/reset-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function post(tokenEmail: string, userId = '42') {
+  const token = generatePasswordResetToken(tokenEmail, userId)
+  return POST(makeRequest({ token, password: 'newpassword123' }))
+}
+
+describe('POST /api/auth/reset-password — email normalisation', () => {
+  beforeEach(() => {
+    capturedQueries.length = 0
+  })
+
+  it('lowercases the token address before the users lookup', async () => {
+    await post('Mixed.Case@Example.COM')
+
+    const lookup = capturedQueries[0]
+    expect(lookup.sql).toContain('from `users`')
+    expect(lookup.sql).toContain('`email` = ?')
+    expect(lookup.parameters[0]).toBe('mixed.case@example.com')
+  })
+
+  it('trims surrounding whitespace before the users lookup', async () => {
+    await post('  employee@test.com \n')
+
+    expect(capturedQueries[0].parameters[0]).toBe('employee@test.com')
+  })
+
+  it('handles mixed case and padding together', async () => {
+    await post('\t ADMIN@Test.Com  ')
+
+    expect(capturedQueries[0].parameters[0]).toBe('admin@test.com')
+  })
+
+  it('still scopes the lookup to the token user id', async () => {
+    await post('Mixed.Case@Example.COM', '1252')
+
+    // Normalising the address must not have disturbed the second predicate —
+    // the id is what stops one account's token resetting another's password.
+    expect(capturedQueries[0].sql).toContain('`id` = ?')
+    expect(capturedQueries[0].parameters[1]).toBe(1252)
+  })
+
+  it('rejects an invalid token before any query runs', async () => {
+    const res = await POST(makeRequest({ token: 'not-a-jwt', password: 'newpassword123' }))
+
+    expect(res.status).toBe(400)
+    expect(capturedQueries).toHaveLength(0)
+  })
+
+  it('rejects a short password before any query runs', async () => {
+    const token = generatePasswordResetToken('employee@test.com', '42')
+    const res = await POST(makeRequest({ token, password: 'short' }))
+
+    expect(res.status).toBe(400)
+    expect(capturedQueries).toHaveLength(0)
+  })
+
+  it('404s when the normalised address matches no user', async () => {
+    const res = await post('Nobody@Example.com')
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/src/app/api/auth/request-reset/route.ts
+++ b/src/app/api/auth/request-reset/route.ts
@@ -6,6 +6,7 @@ import { Resend } from 'resend'
 import PasswordResetEmail from '@/components/emails/PasswordResetEmail'
 import React from 'react'
 import { logger } from '@/lib/utils/logger'
+import { normalizeEmail } from '@/lib/utils/email'
 
 export async function POST(request: Request) {
   try {
@@ -22,7 +23,7 @@ export async function POST(request: Request) {
     const user = await db
       .selectFrom('users')
       .select(['id', 'email'])
-      .where('email', '=', email.toLowerCase())
+      .where('email', '=', normalizeEmail(email))
       .executeTakeFirst()
 
     // Always return success to prevent email enumeration

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/database/client'
 import { validatePasswordResetToken } from '@/lib/auth/password-reset'
 import bcrypt from 'bcryptjs'
 import { logger } from '@/lib/utils/logger'
+import { normalizeEmail } from '@/lib/utils/email'
 
 export async function POST(request: Request) {
   try {
@@ -35,7 +36,7 @@ export async function POST(request: Request) {
     const user = await db
       .selectFrom('users')
       .select(['id', 'email'])
-      .where('email', '=', payload.email)
+      .where('email', '=', normalizeEmail(payload.email))
       .where('id', '=', parseInt(payload.userId))
       .executeTakeFirst()
 

--- a/src/app/api/employees/[id]/create-user/__tests__/route.email-normalization.test.ts
+++ b/src/app/api/employees/[id]/create-user/__tests__/route.email-normalization.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment node
+ *
+ * The "is there already a login for this address?" probe in the create-user
+ * route is a raw email-equality lookup that the Phase 1 doc's site list missed.
+ * It now normalises the employee's stored address before comparing.
+ *
+ * The sibling `route.test.ts` drives a chainable mock, which cannot see the
+ * values bound into a predicate built from an `eb` callback. Here the route
+ * runs against a real Kysely compiler wired to a canned-row driver, so both the
+ * emitted SQL and its parameters are observable.
+ */
+/* eslint-disable no-var */
+var capturedQueries: { sql: string; parameters: readonly unknown[] }[]
+// Rows the existing-login probe replays. Emptied by the tests that need the
+// route to fall through to the INSERT branch.
+var probeRows: Record<string, unknown>[]
+/* eslint-enable no-var */
+
+// Row fixtures the fake driver replays, keyed by the table the query reads.
+// Deliberately mixed-case + padded: the stored value is what the route must
+// normalise before probing `users`.
+const EMPLOYEE_ROW = { id: '42', name: 'D Spiker', email: '  Mixed.Case@Example.COM ' }
+const USER_ROW = { uid: 7, id: 42, email: 'Mixed.Case@Example.COM', role: 'subscriber' }
+const CREATED_USER_ROW = { id: 91, email: 'mixed.case@example.com', role: 'subscriber' }
+
+jest.mock('@/lib/database/client', () => {
+  const {
+    Kysely,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+  } = jest.requireActual('kysely')
+
+  capturedQueries = []
+  // The fixtures above are still in their TDZ while this factory runs, so the
+  // meaningful default is installed by `beforeEach`.
+  probeRows = []
+
+  const connection = {
+    async executeQuery(compiled: { sql: string; parameters: readonly unknown[] }) {
+      capturedQueries.push({ sql: compiled.sql, parameters: compiled.parameters })
+
+      // `employee_user` must come back empty or the route 409s before the
+      // users probe we are here to observe.
+      if (compiled.sql.includes('from `employee_user`')) return { rows: [] }
+      if (compiled.sql.includes('from `employees`')) return { rows: [EMPLOYEE_ROW] }
+      if (compiled.sql.includes('from `users`')) {
+        // The read-back of the row the INSERT branch just created is keyed by
+        // `uid`; the existing-login probe is the `id = ? or email = ?` one.
+        if (compiled.sql.includes('`uid` = ?')) return { rows: [CREATED_USER_ROW] }
+        return { rows: probeRows }
+      }
+      if (compiled.sql.includes('insert into `users`')) {
+        return { rows: [], insertId: BigInt(91), numAffectedRows: BigInt(1) }
+      }
+      return { rows: [] }
+    },
+    async *streamQuery() {},
+  }
+
+  const driver = {
+    async init() {},
+    async acquireConnection() {
+      return connection
+    },
+    async beginTransaction() {},
+    async commitTransaction() {},
+    async rollbackTransaction() {},
+    async releaseConnection() {},
+    async destroy() {},
+  }
+
+  return {
+    db: new Kysely({
+      dialect: {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => driver,
+        createIntrospector: (kysely: never) => new MysqlIntrospector(kysely),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      },
+    }),
+  }
+})
+
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }))
+jest.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+jest.mock('bcryptjs', () => ({ hash: jest.fn().mockResolvedValue('$2a$12$hashed') }))
+jest.mock('@/lib/services/email', () => ({
+  sendWelcomeEmail: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}))
+
+import { POST } from '../route'
+import { getServerSession } from 'next-auth'
+import { sendWelcomeEmail } from '@/lib/services/email'
+
+function makeRequest(employeeId: string) {
+  return new Request(`http://localhost:3000/api/employees/${employeeId}/create-user`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role: 'subscriber' }),
+  })
+}
+
+/** The probe that ORs the legacy id convention with the email match. */
+function usersProbe() {
+  const probe = capturedQueries.find((q) => q.sql.includes('from `users`'))
+  if (!probe) throw new Error('the users probe never ran')
+  return probe
+}
+
+/** The INSERT that creates the login when the probe finds nothing. */
+function usersInsert() {
+  const insert = capturedQueries.find((q) => q.sql.includes('insert into `users`'))
+  if (!insert) throw new Error('the users insert never ran')
+  return insert
+}
+
+describe('POST /api/employees/[id]/create-user — email normalisation', () => {
+  beforeEach(() => {
+    capturedQueries.length = 0
+    probeRows = [USER_ROW]
+    ;(sendWelcomeEmail as jest.Mock).mockClear()
+    ;(getServerSession as jest.Mock).mockResolvedValue({ user: { isAdmin: true } })
+  })
+
+  it('normalises the stored employee address before probing users', async () => {
+    const res = await POST(makeRequest('42'), { params: Promise.resolve({ id: '42' }) })
+    expect(res.status).toBe(200)
+
+    const probe = usersProbe()
+    expect(probe.sql).toContain('`email` = ?')
+    expect(probe.parameters).toContain('mixed.case@example.com')
+    // The un-normalised stored value must not be what was bound.
+    expect(probe.parameters).not.toContain(EMPLOYEE_ROW.email)
+  })
+
+  it('leaves the legacy users.id arm of the OR intact', async () => {
+    await POST(makeRequest('42'), { params: Promise.resolve({ id: '42' }) })
+
+    const probe = usersProbe()
+    // ~93% of production logins are linked by `users`.id = `employees`.id, so
+    // dropping this arm would create duplicate login rows.
+    expect(probe.sql).toMatch(/`id` = \? or `email` = \?/)
+    expect(probe.parameters).toContain('42')
+  })
+
+  it('writes the same canonical address it probed for', async () => {
+    // No existing login: the route falls through to the INSERT. Read and write
+    // must bind the identical string — otherwise, under a case-sensitive
+    // engine, the probe misses a stored mixed-case login and this INSERT then
+    // trips `users_email_unique` (errno 1062 is not caught in this route, so
+    // it surfaces as a 500 instead of the "already existed and has been
+    // linked" 200).
+    probeRows = []
+
+    const res = await POST(makeRequest('42'), { params: Promise.resolve({ id: '42' }) })
+    expect(res.status).toBe(200)
+
+    const probe = usersProbe()
+    const insert = usersInsert()
+
+    expect(insert.parameters).toContain('mixed.case@example.com')
+    expect(insert.parameters).not.toContain(EMPLOYEE_ROW.email)
+
+    // The load-bearing assertion: same value on both sides of the round trip.
+    const probedEmail = probe.parameters[1]
+    expect(insert.parameters).toContain(probedEmail)
+  })
+
+  it('sends the welcome email to the canonical address', async () => {
+    probeRows = []
+
+    await POST(makeRequest('42'), { params: Promise.resolve({ id: '42' }) })
+
+    expect(sendWelcomeEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'mixed.case@example.com' })
+    )
+  })
+
+  it('does not run the probe at all for a non-admin caller', async () => {
+    ;(getServerSession as jest.Mock).mockResolvedValue({ user: { isAdmin: false } })
+
+    const res = await POST(makeRequest('42'), { params: Promise.resolve({ id: '42' }) })
+
+    expect(res.status).toBe(401)
+    expect(capturedQueries).toHaveLength(0)
+  })
+})

--- a/src/app/api/employees/[id]/create-user/route.ts
+++ b/src/app/api/employees/[id]/create-user/route.ts
@@ -6,6 +6,7 @@ import bcrypt from 'bcryptjs'
 import { z } from 'zod'
 import { sendWelcomeEmail } from '@/lib/services/email'
 import { logger } from '@/lib/utils/logger'
+import { normalizeEmail } from '@/lib/utils/email'
 
 // Generate secure random password
 function generatePassword(length: number = 10): string {
@@ -75,6 +76,13 @@ export async function POST(
       )
     }
 
+    // Canonical form of the employee's stored address. Used for BOTH the
+    // "does a login already exist?" probe below and the login row this route
+    // may go on to create — probing one string while writing another would,
+    // on a case-sensitive engine, miss an existing mixed-case login and then
+    // collide with `users_email_unique` on the insert.
+    const loginEmail = normalizeEmail(employee.email)
+
     // Check if a user row already exists (by id or email) without an employee_user link
     // This handles the case where users.id = employees.id but employee_user was never created
     const existingUser = await db
@@ -83,7 +91,7 @@ export async function POST(
       .where((eb) =>
         eb.or([
           eb('id', '=', employeeId),
-          eb('email', '=', employee.email),
+          eb('email', '=', loginEmail),
         ])
       )
       .executeTakeFirst()
@@ -129,7 +137,7 @@ export async function POST(
         .insertInto('users')
         .values({
           id: employeeId,
-          email: employee.email,
+          email: loginEmail,
           name: employee.name,
           password: hashedPassword,
           role: role,
@@ -162,7 +170,10 @@ export async function POST(
     // Send welcome email
     try {
       await sendWelcomeEmail({
-        to: employee.email,
+        // Same canonical address that was just stored as the login, so the
+        // credentials in the email match the row (and a padded stored value
+        // cannot produce an undeliverable recipient).
+        to: loginEmail,
         name: employee.name,
         password: password,
       })

--- a/src/lib/auth/__tests__/config.email-normalization.test.ts
+++ b/src/lib/auth/__tests__/config.email-normalization.test.ts
@@ -1,0 +1,241 @@
+/**
+ * @jest-environment node
+ *
+ * NextAuth `authorize` must normalise the submitted address before it reaches
+ * the `users` lookup.
+ *
+ * On MySQL (utf8mb3_unicode_ci) case is already ignored, so the case half of
+ * this is a no-op today and the trim half is a strict improvement. On a
+ * case-sensitive engine it is the difference between a working and a broken
+ * login, which is why the assertion is on the *bound parameter* rather than on
+ * the returned user: the repository mock returns no rows either way.
+ */
+/* eslint-disable no-var */
+var capturedQueries: { sql: string; parameters: readonly unknown[] }[]
+// Rows the fake driver replays per table. Default empty (no user matches), so
+// the normalisation cases below assert on the bound parameter; the success-path
+// case fills them in to drive `authorize` all the way to its return value.
+var userRows: Record<string, unknown>[]
+var employeeRows: Record<string, unknown>[]
+var subscriberRows: Record<string, unknown>[]
+/* eslint-enable no-var */
+
+jest.mock('@/lib/database/client', () => {
+  const {
+    Kysely,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+  } = jest.requireActual('kysely')
+
+  capturedQueries = []
+  userRows = []
+  employeeRows = []
+  subscriberRows = []
+
+  const connection = {
+    async executeQuery(compiled: { sql: string; parameters: readonly unknown[] }) {
+      capturedQueries.push({ sql: compiled.sql, parameters: compiled.parameters })
+
+      if (compiled.sql.includes('from `subscriber_user`')) return { rows: subscriberRows }
+      if (compiled.sql.includes('from `employees`')) return { rows: employeeRows }
+      if (compiled.sql.includes('from `users`')) return { rows: userRows }
+      return { rows: [] }
+    },
+    async *streamQuery() {},
+  }
+
+  return {
+    db: new Kysely({
+      dialect: {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => ({
+          async init() {},
+          async acquireConnection() {
+            return connection
+          },
+          async beginTransaction() {},
+          async commitTransaction() {},
+          async rollbackTransaction() {},
+          async releaseConnection() {},
+          async destroy() {},
+        }),
+        createIntrospector: (kysely: never) => new MysqlIntrospector(kysely),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      },
+    }),
+  }
+})
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}))
+
+import bcrypt from 'bcryptjs'
+import { authOptions } from '../config'
+
+// Real hash, low cost factor: the credential comparison is the one thing in
+// this file that must not be mocked away.
+const PASSWORD_HASH = bcrypt.hashSync('password123', 4)
+
+type Authorize = (
+  credentials: Record<string, string> | undefined
+) => Promise<unknown>
+
+/**
+ * `CredentialsProvider(...)` stores the caller's config under `.options` and
+ * ships an `authorize: () => null` placeholder on the object itself (NextAuth
+ * merges the two at runtime). Reading `.authorize` directly would silently test
+ * that placeholder, so resolve `.options.authorize` and refuse the stub.
+ */
+function getAuthorize(): Authorize {
+  const provider = authOptions.providers[0] as unknown as {
+    authorize?: Authorize
+    options?: { authorize?: Authorize }
+  }
+  const authorize = provider?.options?.authorize
+  if (typeof authorize !== 'function') {
+    throw new Error('credentials provider is not the first configured provider')
+  }
+  return authorize
+}
+
+describe('NextAuth authorize — email normalisation', () => {
+  beforeEach(() => {
+    capturedQueries.length = 0
+    userRows = []
+    employeeRows = []
+    subscriberRows = []
+  })
+
+  it('resolves the real authorize implementation, not the provider stub', async () => {
+    const authorize = getAuthorize()
+    expect(typeof authorize).toBe('function')
+
+    // The NextAuth stub returns null without querying; the real implementation
+    // hits `users`. Without this guard every assertion below could pass
+    // vacuously against the stub.
+    await authorize({ email: 'employee@test.com', password: 'password123' })
+    expect(capturedQueries).toHaveLength(1)
+    expect(capturedQueries[0].sql).toContain('from `users`')
+  })
+
+  it('lowercases the submitted address before the users lookup', async () => {
+    await getAuthorize()({ email: 'Mixed.Case@Example.COM', password: 'password123' })
+
+    const lookup = capturedQueries[0]
+    expect(lookup.sql).toContain('from `users`')
+    expect(lookup.sql).toContain('`email` = ?')
+    expect(lookup.parameters[0]).toBe('mixed.case@example.com')
+  })
+
+  it('trims surrounding whitespace before the users lookup', async () => {
+    await getAuthorize()({ email: '  employee@test.com\t\n', password: 'password123' })
+
+    expect(capturedQueries[0].parameters[0]).toBe('employee@test.com')
+  })
+
+  it('handles mixed case and padding together', async () => {
+    await getAuthorize()({ email: '\t  ADMIN@Test.Com  ', password: 'password123' })
+
+    expect(capturedQueries[0].parameters[0]).toBe('admin@test.com')
+  })
+
+  it('passes an already-canonical address through untouched', async () => {
+    await getAuthorize()({ email: 'manager@test.com', password: 'password123' })
+
+    expect(capturedQueries[0].parameters[0]).toBe('manager@test.com')
+  })
+
+  it('never normalises the password or issues a query without credentials', async () => {
+    // Behaviour guard: missing credentials must still short-circuit to null
+    // before touching the database.
+    await expect(getAuthorize()(undefined)).resolves.toBeNull()
+    await expect(getAuthorize()({ email: '', password: 'password123' })).resolves.toBeNull()
+    await expect(getAuthorize()({ email: 'employee@test.com', password: '' })).resolves.toBeNull()
+
+    expect(capturedQueries).toHaveLength(0)
+  })
+
+  describe('success path (the lookup value changed — authentication must not)', () => {
+    beforeEach(() => {
+      userRows = [
+        { id: 1250, email: 'Manager@Test.com', password: PASSWORD_HASH, name: 'Test Manager' },
+      ]
+      employeeRows = [
+        {
+          employee_id: 1250,
+          employee_name: 'Test Manager',
+          employee_email: 'Manager@Test.com',
+          is_admin: 0,
+          is_mgr: 1,
+          is_super_admin: 0,
+          is_active: 1,
+          sales_id1: 'MGR1',
+          sales_id2: '',
+          sales_id3: null,
+        },
+      ]
+    })
+
+    it('still authenticates a valid credential and returns the same claims', async () => {
+      const user = (await getAuthorize()({
+        email: '  Manager@Test.com ',
+        password: 'password123',
+      })) as Record<string, unknown>
+
+      expect(user).not.toBeNull()
+      expect(user).toMatchObject({
+        id: '1250',
+        // The stored value is returned into the session, not the normalised
+        // lookup key — normalisation is a comparison concern only.
+        email: 'Manager@Test.com',
+        name: 'Test Manager',
+        isAdmin: false,
+        isManager: true,
+        isSuperAdmin: false,
+        isActive: true,
+        isSubscriber: false,
+        employeeId: 1250,
+        salesIds: ['MGR1'],
+      })
+
+      // …and it got there through a normalised lookup.
+      expect(capturedQueries[0].parameters[0]).toBe('manager@test.com')
+    })
+
+    it('still rejects a wrong password for a matching address', async () => {
+      await expect(
+        getAuthorize()({ email: 'manager@test.com', password: 'not-the-password' })
+      ).resolves.toBeNull()
+    })
+
+    it('flags an admin and a subscriber from the same lookup', async () => {
+      employeeRows[0].is_admin = 1
+      employeeRows[0].is_super_admin = 1
+      subscriberRows = [{ subscriber_id: 9 }]
+
+      const user = (await getAuthorize()({
+        email: 'MANAGER@TEST.COM',
+        password: 'password123',
+      })) as Record<string, unknown>
+
+      expect(user).toMatchObject({
+        isAdmin: true,
+        isSuperAdmin: true,
+        isSubscriber: true,
+        subscriberId: 9,
+      })
+    })
+  })
+
+  it('returns null when no user matches (driver returns no rows)', async () => {
+    await expect(
+      getAuthorize()({ email: 'Nobody@Example.com', password: 'password123' })
+    ).resolves.toBeNull()
+
+    // The lookup still ran — and still ran normalised.
+    expect(capturedQueries).toHaveLength(1)
+    expect(capturedQueries[0].parameters[0]).toBe('nobody@example.com')
+  })
+})

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -3,6 +3,7 @@ import CredentialsProvider from 'next-auth/providers/credentials'
 import bcrypt from 'bcryptjs'
 import { db } from '@/lib/database/client'
 import { logger } from '@/lib/utils/logger'
+import { normalizeEmail } from '@/lib/utils/email'
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -18,11 +19,15 @@ export const authOptions: NextAuthOptions = {
         }
 
         try {
-          // Find user by email
+          // Find user by email. The submitted address is normalised (trimmed +
+          // lowercased) before it reaches the query: MySQL's unicode_ci
+          // collation already ignores case, so this only newly tolerates
+          // whitespace-padded input today — but it is load-bearing on a
+          // case-sensitive engine.
           const user = await db
             .selectFrom('users')
             .select(['id', 'email', 'password', 'name'])
-            .where('email', '=', credentials.email)
+            .where('email', '=', normalizeEmail(credentials.email))
             .executeTakeFirst()
 
           if (!user) {

--- a/src/lib/repositories/EmployeeRepository.ts
+++ b/src/lib/repositories/EmployeeRepository.ts
@@ -582,9 +582,14 @@ export class EmployeeRepository {
 
         // Idempotent: re-deleting must never double-prefix an already parked address.
         if (!isParkedEmail(user.email)) {
-          let parked = buildParkedEmail(id, user.email)
+          // Canonicalise once, here, so the value the collision guard probes is
+          // byte-for-byte the value the UPDATE below writes. Normalising only
+          // inside the guard would make it answer a question about a string
+          // that never reaches the table.
+          const base = normalizeEmail(user.email)
+          let parked = buildParkedEmail(id, base)
           if (await this.emailTakenByOtherUser(trx, parked, user.uid)) {
-            parked = buildParkedEmail(id, user.email, user.uid)
+            parked = buildParkedEmail(id, base, user.uid)
           }
           userUpdate.email = parked
         }
@@ -1182,7 +1187,7 @@ export class EmployeeRepository {
     const row = await executor
       .selectFrom('users')
       .select('uid')
-      .where('email', '=', email)
+      .where('email', '=', normalizeEmail(email))
       .where('uid', '!=', excludeUid)
       .executeTakeFirst()
 

--- a/src/lib/repositories/InvoiceAuditRepository.ts
+++ b/src/lib/repositories/InvoiceAuditRepository.ts
@@ -519,15 +519,39 @@ export class InvoiceAuditRepository {
       )
     }
 
-    // Apply date filter if provided
+    // Apply date filter if provided.
+    //
+    // Half-open range on the raw column (col >= from AND col < to+1day)
+    // instead of DATE(col): index-friendly and Postgres-portable. Also fixes
+    // the previous calls, which passed a factory function as the `lhs` of the
+    // 3-arg `where(lhs, op, rhs)` overload instead of the intended 1-arg
+    // `where(callback)` form — Kysely's `ReferenceExpression` happens to
+    // accept a factory there today, but that's an accident of the type, not
+    // the documented API; passing a boolean-returning expression per column
+    // is what the API actually asks for.
+    //
+    // Unparseable input is rejected explicitly rather than bound as a JS
+    // `Invalid Date`. The driver serialises an Invalid Date to the SQL literal
+    // `NULL`, so `changed_at >= NULL` would silently match zero rows and the
+    // dashboard would report "no audit activity ever" instead of failing. The
+    // pre-fix code bound the string 'Invalid Date', which the engine rejected
+    // with a hard error (HTTP 500 via the route's catch); throwing here keeps
+    // that loud failure — the contract callers see today — while making the
+    // cause legible in the logs.
     if (dateFrom) {
-      const fromDate = dayjs(dateFrom, 'MM-DD-YYYY').format('YYYY-MM-DD')
-      baseQuery = baseQuery.where(({ eb }) => eb.fn('DATE', ['ia.changed_at']), '>=', fromDate)
+      const from = dayjs(dateFrom, 'MM-DD-YYYY')
+      if (!from.isValid()) {
+        throw new Error(`Invalid dateFrom filter: ${dateFrom}`)
+      }
+      baseQuery = baseQuery.where('ia.changed_at', '>=', from.startOf('day').toDate())
     }
 
     if (dateTo) {
-      const toDate = dayjs(dateTo, 'MM-DD-YYYY').format('YYYY-MM-DD')
-      baseQuery = baseQuery.where(({ eb }) => eb.fn('DATE', ['ia.changed_at']), '<=', toDate)
+      const to = dayjs(dateTo, 'MM-DD-YYYY')
+      if (!to.isValid()) {
+        throw new Error(`Invalid dateTo filter: ${dateTo}`)
+      }
+      baseQuery = baseQuery.where('ia.changed_at', '<', to.add(1, 'day').startOf('day').toDate())
     }
 
     // Get total changes
@@ -547,10 +571,11 @@ export class InvoiceAuditRepository {
       .select(({ fn }) => fn.count<number>('id').as('count'))
       .executeTakeFirst()
 
-    // Get recent changes (last 30 days)
-    const thirtyDaysAgo = dayjs().subtract(30, 'day').format('YYYY-MM-DD')
+    // Get recent changes (last 30 days) — same fix: raw-column comparison
+    // instead of a factory passed where an expression was expected.
+    const thirtyDaysAgo = dayjs().subtract(30, 'day').startOf('day').toDate()
     const recentChanges = await baseQuery
-      .where(({ eb }) => eb.fn('DATE', ['changed_at']), '>=', thirtyDaysAgo)
+      .where('ia.changed_at', '>=', thirtyDaysAgo)
       .select(({ fn }) => fn.count<number>('id').as('count'))
       .executeTakeFirst()
 

--- a/src/lib/repositories/PayrollRepository.ts
+++ b/src/lib/repositories/PayrollRepository.ts
@@ -4,6 +4,7 @@ import { AdvanceRepository } from '@/lib/repositories/AdvanceRepository'
 import { VendorFieldRepository } from '@/lib/repositories/VendorFieldRepository'
 import { isFeatureEnabled } from '@/lib/feature-flags'
 import { logger } from '@/lib/utils/logger'
+import { safeJsonParse } from '@/lib/utils/safe-json'
 import { accessibleEmployeeIds, type UserContext } from '@/lib/auth/types'
 import {
   getEmployeeVisibilityCutoff,
@@ -667,16 +668,13 @@ export class PayrollRepository {
 
     // Parse custom_fields JSON for each sale
     const salesWithCustomFields = sales.map(sale => {
-      let customFields: Record<string, string> | undefined
-      try {
-        if (sale.custom_fields) {
-          customFields = typeof sale.custom_fields === 'string'
-            ? JSON.parse(sale.custom_fields)
-            : sale.custom_fields as unknown as Record<string, string>
-        }
-      } catch (e) {
-        logger.warn('Failed to parse custom_fields for invoice', sale.invoice_id, e)
-      }
+      const customFields = sale.custom_fields
+        ? safeJsonParse<Record<string, string> | undefined>(
+            sale.custom_fields,
+            undefined,
+            `PayrollRepository.custom_fields (invoice ${sale.invoice_id})`
+          )
+        : undefined
       return { ...sale, custom_fields: customFields }
     })
 

--- a/src/lib/repositories/ProductMarketingRepository.ts
+++ b/src/lib/repositories/ProductMarketingRepository.ts
@@ -1,4 +1,5 @@
 import { db } from '@/lib/database/client'
+import { safeJsonParse } from '@/lib/utils/safe-json'
 
 export interface MarketingProduct {
   // product fields
@@ -77,13 +78,12 @@ export class ProductMarketingRepository {
     const mapped = rows.map((row) => ({
       ...row,
       feature_list: (() => {
-        if (typeof row.feature_list !== 'string') return []
-        try {
-          const parsed = JSON.parse(row.feature_list)
-          return Array.isArray(parsed) ? parsed : []
-        } catch {
-          return []
-        }
+        const parsed = safeJsonParse<unknown>(
+          row.feature_list,
+          [],
+          `ProductMarketingRepository.feature_list (product ${row.product_id})`
+        )
+        return Array.isArray(parsed) ? parsed : []
       })(),
       is_featured: !!row.is_featured,
     }))

--- a/src/lib/repositories/__tests__/EmployeeRepository.email-normalization.test.ts
+++ b/src/lib/repositories/__tests__/EmployeeRepository.email-normalization.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Bound-parameter assertions for the repository's email-equality lookups.
+ *
+ * `EmployeeRepository.email-sql.test.ts` pins the *shape* of these queries;
+ * this file pins the *values* — every address compared against an email column
+ * must arrive trimmed and lowercased, via the shared `normalizeEmail` helper,
+ * and (for the soft-delete parking path) the value that is probed must be the
+ * same string that is written.
+ */
+/* eslint-disable no-var */
+var capturedQueries: { sql: string; parameters: readonly unknown[] }[]
+// Rows the `users` reads replay. `linkedUserRows` answers `getLinkedUsers`;
+// `guardRows` answers the `emailTakenByOtherUser` collision probe (the query
+// carrying the `uid != ?` exclusion).
+var linkedUserRows: Record<string, unknown>[]
+var guardRows: Record<string, unknown>[]
+/* eslint-enable no-var */
+
+jest.mock('@/lib/database/client', () => {
+  const {
+    Kysely,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+  } = jest.requireActual('kysely')
+
+  capturedQueries = []
+  linkedUserRows = []
+  guardRows = []
+
+  const connection = {
+    async executeQuery(compiled: { sql: string; parameters: readonly unknown[] }) {
+      capturedQueries.push({ sql: compiled.sql, parameters: compiled.parameters })
+
+      if (compiled.sql.includes('from `users`')) {
+        return { rows: compiled.sql.includes('`uid` != ?') ? guardRows : linkedUserRows }
+      }
+      return { rows: [], numAffectedRows: BigInt(1) }
+    },
+    async *streamQuery() {},
+  }
+
+  return {
+    db: new Kysely({
+      dialect: {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => ({
+          async init() {},
+          async acquireConnection() {
+            return connection
+          },
+          async beginTransaction() {},
+          async commitTransaction() {},
+          async rollbackTransaction() {},
+          async releaseConnection() {},
+          async destroy() {},
+        }),
+        createIntrospector: (kysely: never) => new MysqlIntrospector(kysely),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      },
+    }),
+  }
+})
+
+import { EmployeeRepository } from '../EmployeeRepository'
+import type { UserContext } from '@/lib/auth/types'
+
+type EmailTakenByOtherUser = (
+  executor: unknown,
+  email: string,
+  excludeUid: number
+) => Promise<boolean>
+
+const ADMIN = { isAdmin: true, isManager: false } as unknown as UserContext
+
+describe('EmployeeRepository — email lookups are normalised', () => {
+  let repo: EmployeeRepository
+
+  beforeEach(() => {
+    capturedQueries.length = 0
+    linkedUserRows = []
+    guardRows = []
+    repo = new EmployeeRepository()
+  })
+
+  describe('emailTakenByOtherUser', () => {
+    function call(email: string, excludeUid = 7) {
+      const { db } = jest.requireMock('@/lib/database/client')
+      const fn = (repo as unknown as { emailTakenByOtherUser: EmailTakenByOtherUser })
+        .emailTakenByOtherUser.bind(repo)
+      return fn(db, email, excludeUid)
+    }
+
+    it('lowercases the probed address', async () => {
+      await call('deleted-42.Mixed.Case@Example.COM')
+
+      const probe = capturedQueries[0]
+      expect(probe.sql).toContain('from `users`')
+      expect(probe.sql).toContain('`email` = ?')
+      expect(probe.parameters[0]).toBe('deleted-42.mixed.case@example.com')
+    })
+
+    it('still excludes the account being parked', async () => {
+      await call('deleted-42.Employee@Test.com', 1250)
+
+      // Normalising the address must not disturb the uid exclusion — without it
+      // an account would collide with its own parked value.
+      expect(capturedQueries[0].sql).toContain('`uid` != ?')
+      expect(capturedQueries[0].parameters[1]).toBe(1250)
+    })
+  })
+
+  describe('softDeleteEmployee — the probed value is the written value', () => {
+    /** The collision guard: the only `users` read carrying `uid != ?`. */
+    function guardQuery() {
+      const guard = capturedQueries.find((q) => q.sql.includes('`uid` != ?'))
+      if (!guard) throw new Error('the collision guard never ran')
+      return guard
+    }
+
+    /** The UPDATE that parks the login email. */
+    function userUpdate() {
+      const update = capturedQueries.find(
+        (q) => q.sql.includes('update `users`') && q.sql.includes('`email` = ?')
+      )
+      if (!update) throw new Error('the users email update never ran')
+      return update
+    }
+
+    it('parks the canonical address it just probed for', async () => {
+      // Stored login carries mixed case (10 such rows exist in the prod
+      // snapshot). Guard finds nothing, so the plain prefix is used.
+      linkedUserRows = [
+        { uid: 7, id: 42, email: 'Mixed.Case@Example.COM', role: 'subscriber', created_at: null },
+      ]
+
+      await repo.softDeleteEmployee(42, ADMIN)
+
+      const probed = guardQuery().parameters[0]
+      expect(probed).toBe('deleted-42.mixed.case@example.com')
+
+      // The load-bearing assertion: under a case-sensitive engine, asking about
+      // one string and writing another lets the UPDATE trip
+      // `users_email_unique` inside the transaction, which rolls the whole
+      // soft-delete back.
+      expect(userUpdate().parameters).toContain(probed)
+    })
+
+    it('uses the same canonical base for the uid-qualified fallback', async () => {
+      linkedUserRows = [
+        { uid: 7, id: 42, email: 'Mixed.Case@Example.COM', role: 'subscriber', created_at: null },
+      ]
+      // Guard reports the plain parked form as taken → fallback prefix.
+      guardRows = [{ uid: 99 }]
+
+      await repo.softDeleteEmployee(42, ADMIN)
+
+      expect(userUpdate().parameters).toContain('deleted-42-7.mixed.case@example.com')
+    })
+
+    it('leaves an already-parked address alone (parking stays idempotent)', async () => {
+      linkedUserRows = [
+        {
+          uid: 7,
+          id: 42,
+          email: 'deleted-42.mixed.case@example.com',
+          role: 'subscriber',
+          created_at: null,
+        },
+      ]
+
+      await repo.softDeleteEmployee(42, ADMIN)
+
+      expect(capturedQueries.some((q) => q.sql.includes('`uid` != ?'))).toBe(false)
+      const update = capturedQueries.find((q) => q.sql.includes('update `users`'))
+      expect(update?.sql).not.toContain('`email` = ?')
+    })
+  })
+
+  describe('findEmailOwner (already normalised — regression guard)', () => {
+    it('normalises the address for both the employees and users lookups', async () => {
+      await repo.findEmailOwner('  Mixed.Case@Example.COM ')
+
+      const [employeeQuery, userQuery] = capturedQueries
+      expect(employeeQuery.sql).toContain('from `employees`')
+      expect(employeeQuery.parameters[0]).toBe('mixed.case@example.com')
+      expect(userQuery.sql).toContain('from `users`')
+      expect(userQuery.parameters[0]).toBe('mixed.case@example.com')
+    })
+  })
+})

--- a/src/lib/repositories/__tests__/InvoiceAuditRepository.audit-summary-sql.test.ts
+++ b/src/lib/repositories/__tests__/InvoiceAuditRepository.audit-summary-sql.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Compile-only SQL assertions for InvoiceAuditRepository.getAuditSummary's
+ * date-range filter.
+ *
+ * getAuditSummary used to build its date filter as
+ * `.where(({ eb }) => eb.fn('DATE', [...]), '>=', fromDate)` — a factory
+ * function passed as the `lhs` of the 3-arg `where(lhs, op, rhs)` overload,
+ * instead of the 1-arg `where(callback)` form Kysely's `where` API is meant
+ * to be used with for building boolean expressions. The fix replaces the
+ * DATE()-wrapped column with a half-open range on the raw column
+ * (col >= from AND col < to+1day): sargable and Postgres-portable.
+ *
+ * Following the pattern in EmployeeRepository.email-sql.test.ts: drive a real
+ * Kysely instance wired to a compile-only (Dummy) driver so the emitted MySQL
+ * — and the exact bound parameters — are asserted verbatim. A hand-rolled
+ * chainable `where` mock (as used in InvoiceAuditRepository.rbac.test.ts)
+ * can't see *inside* the predicate being built, so it can't catch this class
+ * of bug.
+ */
+/* eslint-disable no-var */
+var capturedQueries: { sql: string; parameters: readonly unknown[] }[]
+/* eslint-enable no-var */
+
+jest.mock('@/lib/database/client', () => {
+  const {
+    Kysely,
+    MysqlAdapter,
+    MysqlIntrospector,
+    MysqlQueryCompiler,
+    DummyDriver,
+  } = jest.requireActual('kysely')
+
+  capturedQueries = []
+
+  return {
+    db: new Kysely({
+      dialect: {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => new DummyDriver(),
+        createIntrospector: (kysely: never) => new MysqlIntrospector(kysely),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      },
+      log: (event: { level: string; query: { sql: string; parameters: readonly unknown[] } }) => {
+        if (event.level === 'query') {
+          capturedQueries.push({ sql: event.query.sql, parameters: event.query.parameters })
+        }
+      },
+    }),
+  }
+})
+
+import dayjs from 'dayjs'
+import { InvoiceAuditRepository } from '../InvoiceAuditRepository'
+import type { UserContext } from '@/lib/auth/types'
+
+const adminCtx: UserContext = { employeeId: 1, isAdmin: true, isManager: false }
+
+describe('InvoiceAuditRepository.getAuditSummary — date filter SQL', () => {
+  let repo: InvoiceAuditRepository
+
+  beforeEach(() => {
+    repo = new InvoiceAuditRepository()
+    capturedQueries.length = 0
+  })
+
+  it('constrains the totals query to a half-open range on the raw changed_at column', async () => {
+    await repo.getAuditSummary(undefined, '01-01-2026', '01-31-2026', adminCtx)
+
+    // Call order inside getAuditSummary: totalChanges is the first query run.
+    const totalsQuery = capturedQueries[0]
+    expect(totalsQuery.sql).toContain('where `ia`.`changed_at` >= ? and `ia`.`changed_at` < ?')
+
+    // Must not regress to the index-hostile DATE() wrapping.
+    expect(totalsQuery.sql).not.toContain('DATE(')
+
+    const [fromParam, toParam] = totalsQuery.parameters
+    expect(fromParam).toBeInstanceOf(Date)
+    expect(toParam).toBeInstanceOf(Date)
+    // Bounds are asserted in LOCAL time, matching how the repository builds
+    // them (`dayjs(...).startOf('day')` is local midnight) and how mysql2's
+    // sqlstring serialises a Date (local getters). Formatting via
+    // `toISOString()` here would be a UTC round-trip and would report the
+    // previous calendar day under any UTC+ runner timezone — making the
+    // assertion depend on where the suite runs.
+    // Lower bound: start of dateFrom's day.
+    expect(dayjs(fromParam as Date).format('YYYY-MM-DD HH:mm:ss')).toBe('2026-01-01 00:00:00')
+    // Upper bound is EXCLUSIVE: the day *after* dateTo (half-open range), not
+    // dateTo itself — a same-day value here is exactly what the old
+    // DATE(col) <= dateTo comparison produced, and would silently reintroduce
+    // the DATE()-wrapping this fix removes.
+    expect(dayjs(toParam as Date).format('YYYY-MM-DD HH:mm:ss')).toBe('2026-02-01 00:00:00')
+  })
+
+  it('applies the same range to every derived query sharing the base filter (status/amount/recent/top-N)', async () => {
+    await repo.getAuditSummary(undefined, '01-01-2026', '01-31-2026', adminCtx)
+
+    expect(capturedQueries.length).toBeGreaterThanOrEqual(6)
+    for (const q of capturedQueries) {
+      expect(q.sql).toContain('`ia`.`changed_at` >= ?')
+      expect(q.sql).not.toContain('DATE(')
+    }
+  })
+
+  it('constrains the recent-changes (30-day) query to a raw-column lower bound, not DATE()', async () => {
+    await repo.getAuditSummary(undefined, undefined, undefined, adminCtx)
+
+    // Call order: totalChanges(0), statusChanges(1), amountChanges(2),
+    // recentChanges(3), topChangedStatuses(4), topChangingUsers(5).
+    const recentChangesQuery = capturedQueries[3]
+    expect(recentChangesQuery.sql).toContain('`ia`.`changed_at` >= ?')
+    expect(recentChangesQuery.sql).not.toContain('DATE(')
+    expect(recentChangesQuery.parameters[0]).toBeInstanceOf(Date)
+  })
+
+  it('omits the date filter entirely when no bounds are given (no unconstrained DATE() noise)', async () => {
+    await repo.getAuditSummary(undefined, undefined, undefined, adminCtx)
+
+    const totalsQuery = capturedQueries[0]
+    expect(totalsQuery.sql).not.toContain('changed_at')
+  })
+
+  // `dateFrom`/`dateTo` arrive unvalidated off the query string
+  // (src/app/api/invoices/search/route.ts). An unparseable value must not be
+  // bound as a JS `Invalid Date`: the driver serialises that to the SQL literal
+  // `NULL`, so `changed_at >= NULL` is NULL and the dashboard would render
+  // zeroes across the board — a silent wrong answer on a financial audit
+  // surface. Fail loudly instead (the route's catch turns this into the same
+  // HTTP 500 the engine's own type error produced before this change).
+  it.each([
+    ['dateFrom', 'not-a-date', undefined],
+    ['dateTo', undefined, 'not-a-date'],
+  ])('rejects an unparseable %s instead of binding an Invalid Date', async (field, from, to) => {
+    await expect(repo.getAuditSummary(undefined, from, to, adminCtx)).rejects.toThrow(
+      `Invalid ${field} filter: not-a-date`
+    )
+
+    // Nothing may reach the database on the rejected path.
+    expect(capturedQueries).toHaveLength(0)
+  })
+})

--- a/src/lib/utils/__tests__/safe-json.test.ts
+++ b/src/lib/utils/__tests__/safe-json.test.ts
@@ -1,0 +1,60 @@
+import { safeJsonParse } from '@/lib/utils/safe-json'
+import { logger } from '@/lib/utils/logger'
+
+describe('safeJsonParse', () => {
+  it('parses a valid JSON string', () => {
+    expect(safeJsonParse('{"a":1}', {})).toEqual({ a: 1 })
+    expect(safeJsonParse('[1,2,3]', [])).toEqual([1, 2, 3])
+  })
+
+  it('passes through an already-parsed object unchanged', () => {
+    const obj = { a: 1 }
+    expect(safeJsonParse(obj, {})).toBe(obj)
+  })
+
+  it('passes through an already-parsed array unchanged', () => {
+    const arr = [1, 2, 3]
+    expect(safeJsonParse(arr, [])).toBe(arr)
+  })
+
+  it('returns the fallback for null', () => {
+    expect(safeJsonParse(null, 'fallback')).toBe('fallback')
+  })
+
+  it('returns the fallback for undefined', () => {
+    expect(safeJsonParse(undefined, 'fallback')).toBe('fallback')
+  })
+
+  it('returns the fallback and logs a warning for malformed JSON', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    const result = safeJsonParse('{not valid json', 'fallback')
+
+    expect(result).toBe('fallback')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('safeJsonParse')
+
+    warnSpy.mockRestore()
+  })
+
+  it('includes the provided context in the warning log', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    safeJsonParse('{bad', [], 'MyRepo.someField')
+
+    expect(warnSpy.mock.calls[0][0]).toContain('MyRepo.someField')
+
+    warnSpy.mockRestore()
+  })
+
+  it('does not log when value is nullish', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    safeJsonParse(null, 'fallback')
+    safeJsonParse(undefined, 'fallback')
+
+    expect(warnSpy).not.toHaveBeenCalled()
+
+    warnSpy.mockRestore()
+  })
+})

--- a/src/lib/utils/safe-json.ts
+++ b/src/lib/utils/safe-json.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared "defensive JSON parse" helper.
+ *
+ * Several repositories read JSON-ish columns (`custom_fields`, `feature_list`,
+ * ...) that are stored as a JSON-encoded string on MySQL today but arrive
+ * pre-parsed (object/array) once a column moves to Postgres `jsonb` in a later
+ * migration phase. `InvoiceRepository.ts` established the "both ways" guard —
+ * `typeof v === 'string' ? JSON.parse(v) : v` — for that transition; this
+ * helper generalizes it and additionally never throws: malformed JSON is
+ * logged and degrades to a caller-supplied fallback instead of taking down
+ * the request.
+ *
+ * `InvoiceRepository`'s existing inline guard on `custom_fields` predates this
+ * helper and still works; unifying it here is deferred (Phase 2 scope).
+ */
+
+import { logger } from '@/lib/utils/logger'
+
+/**
+ * Parse a value that may already be a string-encoded JSON payload, an
+ * already-parsed value (object/array/etc.), or nullish.
+ *
+ * - `null`/`undefined` → returns `fallback` (no parse attempted, no log).
+ * - non-string values → returned as-is (already parsed).
+ * - string values → `JSON.parse`d; on failure, logs a warning and returns
+ *   `fallback` instead of throwing.
+ *
+ * @param value - the raw column value.
+ * @param fallback - value to return when `value` is nullish or malformed JSON.
+ * @param context - short label included in the warning log to identify the
+ *   call site (e.g. `'PayrollRepository.custom_fields'`).
+ */
+export function safeJsonParse<T>(value: unknown, fallback: T, context?: string): T {
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  if (typeof value !== 'string') {
+    return value as T
+  }
+
+  try {
+    return JSON.parse(value) as T
+  } catch (error) {
+    logger.warn(
+      `safeJsonParse: failed to parse JSON${context ? ` for ${context}` : ''}`,
+      error
+    )
+    return fallback
+  }
+}


### PR DESCRIPTION
## Context

First implementation phase of the planned **MariaDB → Neon Postgres migration** — full rationale, vendor decision, and codebase audit in `docs/postgres-migration-plan.md` (included in this PR). Every change here is a no-op or strict improvement on MySQL today, and becomes load-bearing under a case-sensitive engine later. Nothing in this PR depends on the migration actually happening.

## Changes

**A. Email normalization completed everywhere** — every email-equality lookup in `src/` now binds `normalizeEmail()` (trim + lowercase):
- NextAuth `authorize` (`src/lib/auth/config.ts`)
- Both password-reset routes
- `EmployeeRepository` (incl. the soft-delete parked-email guard, so probe and write bind the same string)
- The create-user route — a 4th site the spec's list missed; also fixes a read/write divergence where the existing-login probe used the normalized email but the INSERT wrote the raw one (caught by adversarial review)

**B. `InvoiceAuditRepository` date filters** — rewritten as half-open range predicates on the raw column (sargable, Postgres-portable) with invalid-date guards. Note: the original audit's claim that the old form was a live bug was **disproven** during implementation — the old form compiled to correct SQL; this is an improvement, not a bugfix. Details in `docs/postgres-migration-phase-1.md`.

**C. Safe JSON parsing** — new `safeJsonParse()` helper (`src/lib/utils/safe-json.ts`); paystub `custom_fields` and marketing `feature_list` parsing no longer throw on malformed or pre-parsed values.

**D. Docs** — full migration plan + Phase 1 spec with recorded audit results:
- Email case-collision audit (local prod snapshot): **clean** — zero collision groups across all 6 email-bearing tables
- `sales_id1/2/3` case-variance audit: **clean**; also confirmed `invoices.agentid` is an INT FK to `employees.id`, so no invoices↔sales_id case-mismatch surface
- → follow-up data migration (`lower(trim(email))`) is a **GO**, to be authored as migration 014 via the ledger

## Process

Implemented by orchestrated subagents with **independent adversarial review per change** and a fix loop. Reviews caught 1 major implementation bug (create-user read/write divergence), 1 major test bug (timezone-dependent assertions, now verified across 6 TZs), and the false spec premise in item B.

## Verification

- Full Jest suite: **521 pass, 2 fail — both pre-existing on `main`** (verified by running them on a clean `origin/main` worktree: `AdvanceRepository.resync.test.ts` TZ-dependent assertion, marketing products route `jest.mock` hoisting bug)
- Lint: zero new issues; `tsc --noEmit`: zero new errors (104 pre-exist identically on main)
- Production build (`bun run build`): passes
- New tests assert on actual bound SQL parameters via a real Kysely compiler and were mutation-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LwwozLE18tgHfFvT6e71f