### PR TITLE
Migration 014: normalize stored emails to lower(trim())

### DIFF
--- a/src/lib/database/migrations/014_normalize_emails.sql
+++ b/src/lib/database/migrations/014_normalize_emails.sql
@@ -1,0 +1,25 @@
+-- Normalize stored login emails to lower(trim(email)) on users + employees.
+--
+-- Part of Phase 1/2 of the Postgres migration (docs/postgres-migration-plan.md):
+-- all email lookups now normalize their input (PR #93), so stored values must be
+-- canonical too — MySQL's ci collation hides case differences today, but a
+-- case-sensitive engine will not.
+--
+-- Audited 2026-08-07 against the prod snapshot: zero case-collision groups and
+-- zero whitespace-padded emails in either table, so this cannot merge distinct
+-- accounts. Under the ci collation a case-variant duplicate would already
+-- collide, so lowercasing cannot introduce a new unique-key violation either.
+--
+-- The WHERE uses a BINARY cast: under ci collation `email <> LOWER(email)` is
+-- false for pure case differences, which would silently skip every row this
+-- migration exists to fix.
+
+UPDATE users
+SET email = LOWER(TRIM(email))
+WHERE email IS NOT NULL
+  AND CAST(email AS BINARY) <> CAST(LOWER(TRIM(email)) AS BINARY);
+
+UPDATE employees
+SET email = LOWER(TRIM(email))
+WHERE email IS NOT NULL
+  AND CAST(email AS BINARY) <> CAST(LOWER(TRIM(email)) AS BINARY);


### PR DESCRIPTION
## What

One data migration: `UPDATE users / employees SET email = LOWER(TRIM(email))` for rows whose stored value isn't already canonical. Runs on merge via the CI migration runner (`migrations` ledger).

## Why

Follow-up to #93, which normalized every email *lookup* — stored values must be canonical too before the Postgres migration removes MySQL's case-insensitive collation safety net (`docs/postgres-migration-plan.md`).

## Safety

- Audited 2026-08-07 against the prod snapshot: exactly **9 `users` + 10 `employees`** rows affected; **zero** case-collision groups (no two distinct accounts collapse to the same lowered email); **zero** whitespace-padded emails. The update cannot merge distinct accounts.
- Under the ci collation, case-variant duplicates would already collide on any unique index — lowercasing cannot introduce a new violation.
- The `WHERE` compares through `CAST(... AS BINARY)`; a plain `email <> LOWER(email)` is false under ci collation for case-only differences and would silently skip every targeted row.
- MariaDB 10.6 (prod) / MySQL 8 (dev) common-subset SQL only.

## Verified locally

`bun run db:migrate` against `choice-mysql-dev` (prod snapshot): 19 rows updated, 0 un-normalized rows remaining, 0 duplicate `lower()` groups, ledger row `014_normalize_emails.sql` recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LwwozLE18tgHfFvT6e71f